### PR TITLE
Revise Dockerfiles to use caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,8 @@
-# Start by building the application.
-FROM golang:1.20.5-bullseye as build
-
-WORKDIR /go/src/fleet-telemetry
-
-COPY . .
-ENV CGO_ENABLED=1
-
-RUN make
-
+# start the fleet-telemetry server
 # hadolint ignore=DL3006
 FROM gcr.io/distroless/base-debian11
 WORKDIR /
-COPY --from=build /go/bin/fleet-telemetry /
+
+COPY --from=fleet-telemetry-integration-tests /go/bin/fleet-telemetry /
 
 CMD ["/fleet-telemetry", "-config", "/etc/fleet-telemetry/config.json"]

--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -1,6 +1,17 @@
+# build executable and run integration tests
 FROM golang:1.20.5-bullseye
 
-COPY . /go/src/fleet-telemetry
+ENV CGO_ENABLED=1
+
+WORKDIR /go/src/fleet-telemetry
+
+COPY go.* ./
+RUN go mod download
+
+COPY . ./
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+go build -o /go/bin/fleet-telemetry cmd/main.go
 
 WORKDIR /go/src/fleet-telemetry/test/integration
 

--- a/test/integration/pretest.sh
+++ b/test/integration/pretest.sh
@@ -8,4 +8,4 @@ else
   IT_TARGET_PKGS="./..."
 fi
 
-docker build -t fleet-telemetry-integration-tests --build-arg it_target="${IT_TARGET_PKGS}" -f test/integration/Dockerfile .
+DOCKER_BUILDKIT=1 docker build -t fleet-telemetry-integration-tests --build-arg it_target="${IT_TARGET_PKGS}" -f test/integration/Dockerfile .


### PR DESCRIPTION
Revised the Dockerfiles to improve the use caching.

Dependencies are loaded prior to pulling in source code. I have also moved building the binary to the `test/integration/Dockerfile`. Then, the root `Dockerfile` can pull the binary from tagged image. This prevents needing to load dependencies twice.

### Before
`make integration` takes 2 minutes 15 seconds on every build.

### After
`make integration` takes 58 seconds on all builds, unless there are changes to `go.mod` or `go.sum`.

That's some Plaid acceleration!

---
Side note: This makes use of BuildKit which replaces the legacy builder. It is the default builder in latest Docker version. This will still work for users not on latest Docker version as the environment variable `DOCKER_BUILDKIT` is set.

Closes #35 