### PR TITLE
upgrade confluence platform dependencies in integration tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
         condition: service_started
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.2.1
+    image: confluentinc/cp-zookeeper:7.2.6
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -41,7 +41,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   kafka:
-    image: confluentinc/cp-kafka:7.2.1
+    image: confluentinc/cp-kafka:7.2.6
     hostname: kafka
     container_name: kafka
     depends_on:


### PR DESCRIPTION
Fixes CVEs in Confluence Platform dependencies used in integration tests.

Security release notes from 2.2.1 -> 2.2.6
- [v2.2.2](https://support.confluent.io/hc/en-us/articles/9744629647764-Security-Release-Notes-for-CP-7-2-2)
- [v2.2.3](https://support.confluent.io/hc/en-us/articles/11720533378836-Security-Release-Notes-for-CP-7-2-3)
- [v2.2.4](https://support.confluent.io/hc/en-us/articles/13481185512980-Security-Release-Notes-for-CP-7-2-4)
- [v2.2.5](https://support.confluent.io/hc/en-us/articles/14631251578260-Security-Release-Notes-for-CP-7-2-5)
- [v2.2.6](https://support.confluent.io/hc/en-us/articles/17308847664148-Security-Release-Notes-for-CP-7-2-6)