### PR TITLE
Convert Location field to proper Location type

### DIFF
--- a/telemetry/record_test.go
+++ b/telemetry/record_test.go
@@ -2,13 +2,15 @@ package telemetry_test
 
 import (
 	"crypto/rand"
+	"github.com/sirupsen/logrus"
+	"sort"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/sirupsen/logrus/hooks/test"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/teslamotors/fleet-telemetry/messages"
 	"github.com/teslamotors/fleet-telemetry/protos"
@@ -16,9 +18,14 @@ import (
 )
 
 var _ = Describe("Socket handler test", func() {
-	It("validates the message size", func() {
-		logger, _ := test.NewNullLogger()
-		serializer := telemetry.NewBinarySerializer(
+	var (
+		logger     *logrus.Logger
+		serializer *telemetry.BinarySerializer
+	)
+
+	BeforeEach(func() {
+		logger, _ = test.NewNullLogger()
+		serializer = telemetry.NewBinarySerializer(
 			&telemetry.RequestIdentity{
 				DeviceID: "42",
 				SenderID: "vehicle_device.42",
@@ -27,6 +34,9 @@ var _ = Describe("Socket handler test", func() {
 			false,
 			logger,
 		)
+	})
+
+	It("validates the message size", func() {
 		raw := make([]byte, telemetry.SizeLimit+1)
 		_, _ = rand.Read(raw)
 
@@ -35,17 +45,8 @@ var _ = Describe("Socket handler test", func() {
 		Expect(record).NotTo(BeNil())
 		Expect(record.Serializer).NotTo(BeNil())
 	})
+
 	It("includes vin in body", func() {
-		logger, _ := test.NewNullLogger()
-		serializer := telemetry.NewBinarySerializer(
-			&telemetry.RequestIdentity{
-				DeviceID: "42",
-				SenderID: "vehicle_device.42",
-			},
-			map[string][]telemetry.Producer{"D4": nil},
-			false,
-			logger,
-		)
 		message := messages.StreamMessage{TXID: []byte("1234"), SenderID: []byte("vehicle_device.42"), MessageTopic: []byte("V"), Payload: generatePayload("cybertruck", "42", nil)}
 		recordMsg, err := message.ToBytes()
 		Expect(err).NotTo(HaveOccurred())
@@ -60,18 +61,123 @@ var _ = Describe("Socket handler test", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(data.Vin).To(Equal("42"))
 	})
+
+	It("transforms a valid string location", func() {
+		loc := stringDatum(protos.Field_Location, "(37.412374 N, 122.145867 W)")
+		expected := &protos.LocationValue{Latitude: 37.412374, Longitude: -122.145867}
+
+		message := messages.StreamMessage{TXID: []byte("1234"), SenderID: []byte("vehicle_device.42"), MessageTopic: []byte("V"), Payload: generatePayload("cybertruck", "42", nil, loc)}
+		recordMsg, err := message.ToBytes()
+		Expect(err).NotTo(HaveOccurred())
+
+		record, err := telemetry.NewRecord(serializer, recordMsg, "1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(record).NotTo(BeNil())
+
+		data := &protos.Payload{}
+		err = proto.Unmarshal(record.Payload(), data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data.Data).To(HaveLen(2))
+
+		// Give some predictability to the test
+		sort.Slice(data.Data, func(i, j int) bool {
+			return data.Data[i].Key < data.Data[j].Key
+		})
+
+		first := data.Data[0]
+		Expect(first.Key).To(Equal(protos.Field_Location))
+		Expect(first.Value.GetStringValue()).To(BeEmpty())
+		Expect(first.Value.GetLocationValue()).To(Equal(clone(expected)))
+
+		second := data.Data[1]
+		Expect(second.Key).To(Equal(protos.Field_VehicleName))
+	})
+
+	It("does not transform a bogus string location", func() {
+		expected := "(37.412374 X, 122.145867 W)"
+		loc := stringDatum(protos.Field_Location, expected)
+
+		message := messages.StreamMessage{TXID: []byte("1234"), SenderID: []byte("vehicle_device.42"), MessageTopic: []byte("V"), Payload: generatePayload("cybertruck", "42", nil, loc)}
+		recordMsg, err := message.ToBytes()
+		Expect(err).NotTo(HaveOccurred())
+
+		record, err := telemetry.NewRecord(serializer, recordMsg, "1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(record).NotTo(BeNil())
+
+		data := &protos.Payload{}
+		err = proto.Unmarshal(record.Payload(), data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data.Data).To(HaveLen(2))
+
+		sort.Slice(data.Data, func(i, j int) bool {
+			return data.Data[i].Key < data.Data[j].Key
+		})
+
+		first := data.Data[0]
+		Expect(first.Key).To(Equal(protos.Field_Location))
+		Expect(first.Value.GetStringValue()).To(Equal(expected))
+		Expect(first.Value.GetLocationValue()).To(BeNil())
+
+		second := data.Data[1]
+		Expect(second.Key).To(Equal(protos.Field_VehicleName))
+	})
+
+	It("passes through a valid Location location", func() {
+		expected := &protos.LocationValue{Latitude: 37.412374, Longitude: -122.145867}
+		loc := locationDatum(protos.Field_Location, expected)
+
+		message := messages.StreamMessage{TXID: []byte("1234"), SenderID: []byte("vehicle_device.42"), MessageTopic: []byte("V"), Payload: generatePayload("cybertruck", "42", nil, loc)}
+		recordMsg, err := message.ToBytes()
+		Expect(err).NotTo(HaveOccurred())
+
+		record, err := telemetry.NewRecord(serializer, recordMsg, "1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(record).NotTo(BeNil())
+
+		data := &protos.Payload{}
+		err = proto.Unmarshal(record.Payload(), data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data.Data).To(HaveLen(2))
+
+		sort.Slice(data.Data, func(i, j int) bool {
+			return data.Data[i].Key < data.Data[j].Key
+		})
+
+		first := data.Data[0]
+		Expect(first.Key).To(Equal(protos.Field_Location))
+		Expect(first.Value.GetStringValue()).To(BeEmpty())
+		Expect(first.Value.GetLocationValue()).To(Equal(clone(expected)))
+
+		second := data.Data[1]
+		Expect(second.Key).To(Equal(protos.Field_VehicleName))
+	})
 })
 
-func generatePayload(vehicleName string, vin string, timestamp *timestamppb.Timestamp) []byte {
+var _ = DescribeTable("ParseLocation",
+	func(locStr string, expected *protos.LocationValue, errRegex string) {
+		loc, err := telemetry.ParseLocation(locStr)
+		if errRegex == "" {
+			Expect(err).NotTo(HaveOccurred())
+		} else {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(MatchRegexp(errRegex))
+		}
+		Expect(loc).To(Equal(clone(expected)))
+	},
+	Entry("for a bogus string", "Abhishek is NOT a location", nil, "input does not match format"),
+	Entry("for a broken location", "(37.412374 Q, 122.145867 W)", nil, "invalid location format.*"),
+	Entry("for a valid loc, NW", "(37.412374 N, 122.145867 W)", &protos.LocationValue{Latitude: 37.412374, Longitude: -122.145867}, ""),
+	Entry("for a valid loc, NE", "(37.412374 N, 122.145867 E)", &protos.LocationValue{Latitude: 37.412374, Longitude: 122.145867}, ""),
+	Entry("for a valid loc, SW", "(37.412374 S, 122.145867 W)", &protos.LocationValue{Latitude: -37.412374, Longitude: -122.145867}, ""),
+	Entry("for a valid loc, SE", "(37.412374 S, 122.145867 E)", &protos.LocationValue{Latitude: -37.412374, Longitude: 122.145867}, ""),
+)
+
+func generatePayload(vehicleName string, vin string, timestamp *timestamppb.Timestamp, extraData ...*protos.Datum) []byte {
 	var data []*protos.Datum
-	data = append(data, &protos.Datum{
-		Key: protos.Field_VehicleName,
-		Value: &protos.Value{
-			Value: &protos.Value_StringValue{
-				StringValue: vehicleName,
-			},
-		},
-	})
+	data = append(data, stringDatum(protos.Field_VehicleName, vehicleName))
+	data = append(data, extraData...)
+
 	payload, err := proto.Marshal(&protos.Payload{
 		Vin:       vin,
 		Data:      data,
@@ -79,4 +185,34 @@ func generatePayload(vehicleName string, vin string, timestamp *timestamppb.Time
 	})
 	Expect(err).NotTo(HaveOccurred())
 	return payload
+}
+
+func stringDatum(field protos.Field, value string) *protos.Datum {
+	return &protos.Datum{
+		Key: field,
+		Value: &protos.Value{
+			Value: &protos.Value_StringValue{
+				StringValue: value,
+			},
+		},
+	}
+}
+
+func locationDatum(field protos.Field, location *protos.LocationValue) *protos.Datum {
+	return &protos.Datum{
+		Key: field,
+		Value: &protos.Value{
+			Value: &protos.Value_LocationValue{
+				LocationValue: location,
+			},
+		},
+	}
+}
+
+// clone creates a "clean" clone of the given proto.LocationValue so we can use DeepEqual freely.
+func clone(o *protos.LocationValue) *protos.LocationValue {
+	if o == nil {
+		return nil
+	}
+	return &protos.LocationValue{Latitude: o.Latitude, Longitude: o.Longitude}
 }

--- a/test/integration/server_test.go
+++ b/test/integration/server_test.go
@@ -35,17 +35,24 @@ const (
 	caClient   = "./test-certs/vehicle_device.CA.cert"
 )
 
-func GenerateVehicleMessage(vehicleName string, timestamp *timestamppb.Timestamp) []byte {
-	return tesla.FlatbuffersStreamToBytes([]byte(senderID), []byte("V"), []byte(txid), generatePayload(vehicleName, timestamp), 1, []byte(messageID), []byte(deviceType), []byte(deviceID), uint64(time.Now().UnixMilli()))
+func GenerateVehicleMessage(vehicleName, location string, timestamp *timestamppb.Timestamp) []byte {
+	return tesla.FlatbuffersStreamToBytes([]byte(senderID), []byte("V"), []byte(txid), generatePayload(vehicleName, location, timestamp), 1, []byte(messageID), []byte(deviceType), []byte(deviceID), uint64(time.Now().UnixMilli()))
 }
 
-func generatePayload(vehicleName string, timestamp *timestamppb.Timestamp) []byte {
+func generatePayload(vehicleName, location string, timestamp *timestamppb.Timestamp) []byte {
 	var data []*protos.Datum
 	data = append(data, &protos.Datum{
 		Key: protos.Field_VehicleName,
 		Value: &protos.Value{
 			Value: &protos.Value_StringValue{
 				StringValue: vehicleName,
+			},
+		},
+	}, &protos.Datum{
+		Key: protos.Field_Location,
+		Value: &protos.Value{
+			Value: &protos.Value_StringValue{
+				StringValue: location,
 			},
 		},
 	})


### PR DESCRIPTION
In preparation of vehicles sending their Location as a `protos.Location` value, the server can perform the string->Location transformation to ease the parsing burden on the `Payload` consumers.