### PR TITLE
Clean up test expectations a bit

### DIFF
--- a/config/config_initializer_test.go
+++ b/config/config_initializer_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Test application config initialization", func() {
 		}
 
 		loadedConfig, err := loadTestApplicationConfig(TestConfig)
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 
 		expectedConfig.MetricCollector = loadedConfig.MetricCollector
 		expectedConfig.AckChan = loadedConfig.AckChan
@@ -66,7 +66,7 @@ var _ = Describe("Test application config initialization", func() {
 		}
 
 		loadedConfig, err := loadTestApplicationConfig(TestSmallConfig)
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 
 		expectedConfig.MetricCollector = loadedConfig.MetricCollector
 		expectedConfig.AckChan = loadedConfig.AckChan
@@ -81,10 +81,10 @@ var _ = Describe("Test application config initialization", func() {
 
 func loadTestApplicationConfig(configStr string) (*Config, error) {
 	appConfig, err := os.CreateTemp(os.TempDir(), "config")
-	Expect(err).To(BeNil())
+	Expect(err).NotTo(HaveOccurred())
 
 	_, err = appConfig.Write([]byte(configStr))
-	Expect(err).To(BeNil())
+	Expect(err).NotTo(HaveOccurred())
 	Expect(appConfig.Close()).To(BeNil())
 
 	return loadApplicationConfig(appConfig.Name())

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -57,10 +57,10 @@ var _ = Describe("Test full application config", func() {
 
 		It("fails when pem file is invalid", func() {
 			tmpCA, err := os.CreateTemp(GinkgoT().TempDir(), "tmpCA")
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 
 			_, err = io.WriteString(tmpCA, "-----BEGIN CERTIFICATE-----\nFAKECA\n-----END CERTIFICATE-----")
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 			config.TLS.CAFile = tmpCA.Name()
 
 			_, err = config.ExtractServiceTLSConfig()
@@ -71,10 +71,10 @@ var _ = Describe("Test full application config", func() {
 			config.TLS.CAFile = ""
 
 			tls, err := config.ExtractServiceTLSConfig()
-			Expect(err).To(BeNil())
-			Expect(tls).ToNot(BeNil())
-			Expect(tls.ClientCAs).ToNot(BeNil())
-			Expect(len(tls.ClientCAs.Subjects())).To(Equal(14)) //nolint:staticcheck
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tls).NotTo(BeNil())
+			Expect(tls.ClientCAs).NotTo(BeNil())
+			Expect(tls.ClientCAs.Subjects()).To(HaveLen(14)) //nolint:staticcheck
 		})
 
 		It("uses eng CA", func() {
@@ -82,17 +82,17 @@ var _ = Describe("Test full application config", func() {
 			config.UseDefaultEngCA = true
 
 			tls, err := config.ExtractServiceTLSConfig()
-			Expect(err).To(BeNil())
-			Expect(tls).ToNot(BeNil())
-			Expect(tls.ClientCAs).ToNot(BeNil())
-			Expect(len(tls.ClientCAs.Subjects())).To(Equal(8)) //nolint:staticcheck
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tls).NotTo(BeNil())
+			Expect(tls.ClientCAs).NotTo(BeNil())
+			Expect(tls.ClientCAs.Subjects()).To(HaveLen(8)) //nolint:staticcheck
 		})
 	})
 
 	Context("configure ports", func() {
 		It("use correct ports", func() {
 			config, err := loadTestApplicationConfig(TestSmallConfig)
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(config.Port).To(BeEquivalentTo(443))
 			Expect(config.StatusPort).To(BeEquivalentTo(8080))
 		})
@@ -102,14 +102,14 @@ var _ = Describe("Test full application config", func() {
 		It("converts floats to int", func() {
 			log, _ := test.NewNullLogger()
 			config, err := loadTestApplicationConfig(TestSmallConfig)
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 
 			producers, err := config.ConfigureProducers(log)
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(producers["FS"]).To(HaveLen(1))
 
 			value, err := config.Kafka.Get("queue.buffering.max.messages", 10)
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(value.(int)).To(Equal(1000000))
 		})
 	})
@@ -127,7 +127,7 @@ var _ = Describe("Test full application config", func() {
 		It("returns a map", func() {
 			config.Kinesis = &Kinesis{Streams: map[string]string{"V": "mystream_V", "errors": "mystream_errors"}}
 			err := os.Setenv("KINESIS_STREAM_ERRORS", "test_errors")
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 
 			streamMapping := config.CreateKinesisStreamMapping([]string{"V", "errors", "alerts"})
 			Expect(streamMapping).To(Equal(map[string]string{
@@ -147,7 +147,7 @@ var _ = Describe("Test full application config", func() {
 		BeforeEach(func() {
 			var err error
 			pubsubConfig, err = loadTestApplicationConfig(TestPubsubConfig)
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		AfterEach(func() {
@@ -172,7 +172,7 @@ var _ = Describe("Test full application config", func() {
 			log, _ := test.NewNullLogger()
 			_ = os.Setenv("PUBSUB_EMULATOR_HOST", "some_url")
 			producers, err := pubsubConfig.ConfigureProducers(log)
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(producers["FS"]).NotTo(BeNil())
 		})
 	})
@@ -189,7 +189,7 @@ var _ = Describe("Test full application config", func() {
 		It("fails if not reachable", func() {
 			log, _ := test.NewNullLogger()
 			config.configureMetricsCollector(log)
-			Expect(config.MetricCollector).To(Not(BeNil()))
+			Expect(config.MetricCollector).NotTo(BeNil())
 		})
 	})
 

--- a/datastore/simple/logger_test.go
+++ b/datastore/simple/logger_test.go
@@ -24,12 +24,12 @@ var _ = Describe("Proto Logger", func() {
 	DescribeTable("Proto Parsing",
 		func(txType string, input proto.Message, verifyOutput func(proto.Message) bool) {
 			payloadBytes, err := proto.Marshal(input)
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 			output, err := protoLogger.GetProtoMessage(&telemetry.Record{
 				TxType:       txType,
 				PayloadBytes: payloadBytes,
 			})
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(verifyOutput(output)).To(BeTrue())
 		},
 		Entry("for txType alerts", "alerts", &protos.VehicleAlerts{Vin: "testAlertVin"}, func(msg proto.Message) bool {

--- a/metrics/adapter/prometheus/prometheus_test.go
+++ b/metrics/adapter/prometheus/prometheus_test.go
@@ -20,7 +20,7 @@ import (
 
 func dclose(closer io.Closer) {
 	err := closer.Close()
-	Expect(err).To(BeNil())
+	Expect(err).NotTo(HaveOccurred())
 }
 
 var _ = Describe("Prometheus Metric Adapter", Ordered, func() {
@@ -43,10 +43,10 @@ var _ = Describe("Prometheus Metric Adapter", Ordered, func() {
 
 		getMetrics = func() string {
 			resp, err := httpClient.Get(fmt.Sprintf("http://localhost:%d/metrics", port))
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			body, err := io.ReadAll(resp.Body)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			defer dclose(resp.Body)
 
 			return string(body)

--- a/server/streaming/server_test.go
+++ b/server/streaming/server_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Socket handler test", func() {
 		producerRules := make(map[string][]telemetry.Producer)
 		mux := http.NewServeMux()
 		_, s, err := streaming.InitServer(conf, mux, producerRules, logger, registry)
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 
 		srv := httptest.NewServer(http.HandlerFunc(s.ServeBinaryWs(conf, registry)))
 		u, _ := url.Parse(srv.URL)
@@ -42,13 +42,13 @@ var _ = Describe("Socket handler test", func() {
 
 		dialer := &websocket.Dialer{HandshakeTimeout: 1 * time.Second}
 		conn, _, err := dialer.Dial(u.String(), req.Header)
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 
 		err = conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 
 		err = conn.WriteMessage(websocket.BinaryMessage, []byte(""))
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 
 		_, _, _ = conn.ReadMessage()
 		_ = conn.Close()

--- a/server/streaming/socket_test.go
+++ b/server/streaming/socket_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Socket test", func() {
 			msg := sm.ListenToWriteChannel()
 			Expect(msg.MsgType).To(Equal(2))
 			strMsg, err := messages.StreamMessageFromBytes(msg.Msg)
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(string(strMsg.Payload)).To(Equal("incorrect message format"))
 		})
 
@@ -79,7 +79,7 @@ var _ = Describe("Socket test", func() {
 			msg := sm.ListenToWriteChannel()
 			Expect(msg.MsgType).To(Equal(2))
 			envelope, _, err := tesla.FlatbuffersEnvelopeFromBytes(msg.Msg)
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(envelope.MessageType()).To(Equal(tesla.MessageFlatbuffersStreamAck))
 			lastLogEntry := hook.LastEntry()
 			Expect(lastLogEntry.Message).To(ContainSubstring("unknown_message_type_error"))
@@ -88,14 +88,14 @@ var _ = Describe("Socket test", func() {
 		It("returns error for unknown topic and unmatched sender", func() {
 			record := messages.StreamMessage{TXID: []byte("1234"), MessageTopic: []byte("canlogs"), Payload: []byte("data")}
 			recordMsg, err := record.ToBytes()
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 
 			sm.ParseAndProcessRecord(serializer, recordMsg)
 			msg := sm.ListenToWriteChannel()
 			Expect(msg.MsgType).To(Equal(2))
 
 			streamMessage, err := messages.StreamMessageFromBytes(msg.Msg)
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(string(streamMessage.Payload)).To(Equal("incorrect message format"))
 			firstEntry := hook.Entries[0]
 			Expect(firstEntry.Message).To(ContainSubstring("unexpected_sender_id"))
@@ -106,7 +106,7 @@ var _ = Describe("Socket test", func() {
 		It("topic is verified and no matching sender", func() {
 			record := messages.StreamMessage{TXID: []byte("1234"), SenderID: []byte("SOMEOTHERVIN"), MessageTopic: []byte("D4"), Payload: []byte("data")}
 			recordMsg, err := record.ToBytes()
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 
 			sm.ParseAndProcessRecord(serializer, recordMsg)
 			Expect(hook.Entries).To(HaveLen(0))
@@ -115,7 +115,7 @@ var _ = Describe("Socket test", func() {
 		It("topic is not verified, but sender matches", func() {
 			record := messages.StreamMessage{TXID: []byte("1234"), SenderID: []byte("vehicle_device.42"), MessageTopic: []byte("canlogs"), Payload: []byte("data")}
 			recordMsg, err := record.ToBytes()
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 
 			sm.ParseAndProcessRecord(serializer, recordMsg)
 
@@ -123,7 +123,7 @@ var _ = Describe("Socket test", func() {
 			Expect(msg.MsgType).To(Equal(2))
 
 			streamMessage, err := messages.StreamAckMessageFromBytes(msg.Msg)
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(hook.Entries).To(HaveLen(0))
 
 			Expect(string(streamMessage.MessageTopic)).To(Equal("canlogs"))

--- a/telemetry/record_test.go
+++ b/telemetry/record_test.go
@@ -31,9 +31,9 @@ var _ = Describe("Socket handler test", func() {
 		_, _ = rand.Read(raw)
 
 		record, err := telemetry.NewRecord(serializer, raw, "")
-		Expect(record).To(Not(BeNil()))
-		Expect(err).To(Not(BeNil()))
-		Expect(record.Serializer).To(Not(BeNil()))
+		Expect(err).To(HaveOccurred())
+		Expect(record).NotTo(BeNil())
+		Expect(record.Serializer).NotTo(BeNil())
 	})
 	It("includes vin in body", func() {
 		logger, _ := test.NewNullLogger()
@@ -48,16 +48,16 @@ var _ = Describe("Socket handler test", func() {
 		)
 		message := messages.StreamMessage{TXID: []byte("1234"), SenderID: []byte("vehicle_device.42"), MessageTopic: []byte("V"), Payload: generatePayload("cybertruck", "42", nil)}
 		recordMsg, err := message.ToBytes()
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 
 		record, err := telemetry.NewRecord(serializer, recordMsg, "1")
-		Expect(record).To(Not(BeNil()))
-		Expect(err).To(BeNil())
-		Expect(record.Serializer).To(Not(BeNil()))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(record).NotTo(BeNil())
+		Expect(record.Serializer).NotTo(BeNil())
 
 		data := &protos.Payload{}
 		err = proto.Unmarshal(record.Payload(), data)
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 		Expect(data.Vin).To(Equal("42"))
 	})
 })
@@ -77,6 +77,6 @@ func generatePayload(vehicleName string, vin string, timestamp *timestamppb.Time
 		Data:      data,
 		CreatedAt: timestamp,
 	})
-	Expect(err).To(BeNil())
+	Expect(err).NotTo(HaveOccurred())
 	return payload
 }

--- a/telemetry/serializer_test.go
+++ b/telemetry/serializer_test.go
@@ -160,16 +160,16 @@ var _ = Describe("BinarySerializer", func() {
 			bs := telemetry.NewBinarySerializer(&telemetry.RequestIdentity{DeviceID: tt.fields.DeviceID, SenderID: tt.fields.SenderID}, tt.fields.DispatchRules, false, logger)
 
 			msgBytes, err := tt.args.msg.ToBytes()
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 
 			gotRecord, err := bs.Deserialize(msgBytes, tt.args.socketID)
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 
-			Expect(gotRecord.ReceivedTimestamp).ToNot(Equal(0))
+			Expect(gotRecord.ReceivedTimestamp).NotTo(Equal(0))
 
 			gotRecord.ReceivedTimestamp = 0
 			tt.wantRecord.Serializer = bs
-			Expect(len(gotRecord.RawBytes)).ToNot(Equal(0))
+			Expect(gotRecord.RawBytes).NotTo(BeEmpty())
 			Expect(reflect.DeepEqual(gotRecord.RawBytes, msgBytes)).To(BeFalse())
 
 			tt.wantRecord.RawBytes = gotRecord.RawBytes
@@ -216,7 +216,7 @@ var _ = Describe("BinarySerializer", func() {
 
 		var unknownError *telemetry.UnknownMessageType
 		_, err := bs.Deserialize([]byte("test,1234,type"), "Socket-42")
-		Expect(err).ToNot(BeNil())
+		Expect(err).To(HaveOccurred())
 		Expect(errors.As(err, &unknownError))
 	})
 
@@ -226,7 +226,7 @@ var _ = Describe("BinarySerializer", func() {
 
 		ackBytes := bs.Ack(msg)
 		result, err := messages.StreamAckMessageFromBytes(ackBytes)
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 		Expect(string(result.TXID)).To(Equal("1234"))
 		Expect(string(result.MessageTopic)).To(Equal("test-topic"))
 	})
@@ -238,7 +238,7 @@ var _ = Describe("BinarySerializer", func() {
 
 		errBytes := bs.Error(e, msg)
 		result, err := messages.StreamMessageFromBytes(errBytes)
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 		Expect(string(result.TXID)).To(Equal("1234"))
 		Expect(string(result.Payload)).To(Equal("a bug"))
 	})

--- a/test/integration/google_consumer_test.go
+++ b/test/integration/google_consumer_test.go
@@ -88,7 +88,7 @@ func (c *TestConsumer) ClearSubscriptions() {
 			break
 		}
 		err = sub.Delete(ctx)
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 	}
 }
 

--- a/test/integration/server_test.go
+++ b/test/integration/server_test.go
@@ -53,7 +53,7 @@ func generatePayload(vehicleName string, timestamp *timestamppb.Timestamp) []byt
 		Data:      data,
 		CreatedAt: timestamp,
 	})
-	Expect(err).To(BeNil())
+	Expect(err).NotTo(HaveOccurred())
 	return payload
 }
 
@@ -67,7 +67,7 @@ func CreateWebSocket(tlsConfig *tls.Config) *websocket.Conn {
 		TLSClientConfig:  tlsConfig,
 	}
 	c, _, err := tlsDialer.Dial(u.String(), http.Header{})
-	Expect(err).To(BeNil())
+	Expect(err).NotTo(HaveOccurred())
 	return c
 }
 


### PR DESCRIPTION
* `Expect().To(Not(...))` -> `.NotTo(...)`
* `Expect().ToNot(...)` -> `.NotTo(...)`
* `Expect(err).To(BeNil())` -> `.NotTo(HaveOccurred())`
* `Expect(len(x)).To(Equal(0))` -> `Expect(x).To(BeEmpty())`
* `Expect(len(x)).To(Equal(y))` -> `Expect(x).To(HaveLen(y))`