### PR TITLE
Remove GOOGLE_APPLICATION_CREDENTIALS  or PUBSUB_EMULATOR_HOST check.

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -154,12 +154,6 @@ var _ = Describe("Test full application config", func() {
 			os.Clearenv()
 		})
 
-		It("pubsub does not work when environment variable is not set for emulator", func() {
-			log, _ := test.NewNullLogger()
-			_, err := pubsubConfig.ConfigureProducers(log)
-			Expect(err).To(MatchError("pubsub_connect_error must set environment variable GOOGLE_APPLICATION_CREDENTIALS or PUBSUB_EMULATOR_HOST"))
-		})
-
 		It("pubsub does not work when both the environment variables are set", func() {
 			log, _ := test.NewNullLogger()
 			_ = os.Setenv("PUBSUB_EMULATOR_HOST", "some_url")

--- a/datastore/googlepubsub/publisher.go
+++ b/datastore/googlepubsub/publisher.go
@@ -45,9 +45,6 @@ func configurePubsub(projectID string) (*pubsub.Client, error) {
 	}
 	_, useEmulator := os.LookupEnv("PUBSUB_EMULATOR_HOST")
 	_, useGcpPubsub := os.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS")
-	if !useEmulator && !useGcpPubsub {
-		return nil, errors.New("must set environment variable GOOGLE_APPLICATION_CREDENTIALS or PUBSUB_EMULATOR_HOST")
-	}
 	if useEmulator && useGcpPubsub {
 		return nil, errors.New("pubsub cannot initialize with both emulator and GCP resource")
 	}


### PR DESCRIPTION
When running on GCP with GKE, the preferred authentication is through [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity). 

GOOGLE_APPLICATION_CREDENTIALS env var is not required when using Workload Identity as the Google PubSub library automatically uses metadata server available on GCP. 