### PR TITLE
Add wait timeout during docker compose up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ integration: generate-certs
 	@echo "** RUNNING INTEGRATION TESTS **"
 	./test/integration/pretest.sh
 	docker-compose -p app -f docker-compose.yml build
-	docker-compose -p app -f docker-compose.yml up -d --remove-orphans
+	docker-compose -p app -f docker-compose.yml up --force-recreate --quiet-pull --wait --wait-timeout 180
 	./test/integration/test.sh
 	docker-compose -p app -f docker-compose.yml down
 	@echo "** INTEGRATION TESTS FINISHED **"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,7 @@ services:
 
   pubsub:
     image: google/cloud-sdk:415.0.0
+    platform: linux/x86_64
     ports:
       - '8085:8085'
     command:


### PR DESCRIPTION
# Description

Sometimes docker times out before integration test is ready to run. This change waits till all services are up and healthy before starting running integration tests

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
