### PR TITLE
telemetry::producer::add close method

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -1,0 +1,76 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/teslamotors/fleet-telemetry/config"
+	"github.com/teslamotors/fleet-telemetry/server/monitoring"
+	"github.com/teslamotors/fleet-telemetry/server/streaming"
+)
+
+var (
+	// ShutdownTimeout is the amount of time allotted for the http server to
+	// shutdown.
+	ShutdownTimeout = time.Second * 5
+)
+
+// RunServer runs a fleet telemetry server given its config.
+func RunServer(ctx context.Context, config *config.Config, logger *logrus.Logger) (err error) {
+	logger.Infoln("starting")
+	mux := http.NewServeMux()
+	registry := streaming.NewSocketRegistry()
+
+	monitoring.StartProfilerServer(config, mux, logger)
+	if config.StatusPort > 0 {
+		monitoring.StartStatusServer(config, logger)
+	}
+	if config.Monitoring != nil {
+		monitoring.StartServerMetrics(config, logger, registry)
+	}
+
+	producerRules, err := config.ConfigureProducers(logger)
+	if err != nil {
+		return err
+	}
+
+	server, streamingServer, err := streaming.InitServer(config, mux, producerRules, logger, registry)
+	if err != nil {
+		return err
+	}
+	defer streamingServer.Close()
+
+	if server.TLSConfig, err = config.ExtractServiceTLSConfig(); err != nil {
+		return err
+	}
+
+	// Create a new context in which to run our server.
+	// This context will die when either:
+	// 1. An os.Interrupt is received.
+	// 2. The server encounters a fatal error.
+	ctx, canceller := signal.NotifyContext(ctx, os.Interrupt)
+	serverRunChan := make(chan error)
+
+	// Run the server in the background.
+	// When the server quits, signal the foreground goroutine by closing the
+	// context. Send the error to the foreground via a channel.
+	go func() {
+		err := server.ListenAndServeTLS(config.TLS.ServerCert, config.TLS.ServerKey)
+		canceller()
+		serverRunChan <- err
+	}()
+
+	// Wait for either the server to encounter a fatal error or an interrupt.
+	<-ctx.Done()
+	logger.Infoln("Received interrupt, shutting down...")
+	shutdownContext, canceller := context.WithTimeout(context.Background(), ShutdownTimeout)
+	defer canceller()
+	servErr := server.Shutdown(shutdownContext)
+	shutdownErr := <-serverRunChan
+	return errors.Join(servErr, shutdownErr)
+}

--- a/cmd/run/run_suite_test.go
+++ b/cmd/run/run_suite_test.go
@@ -1,0 +1,12 @@
+package run
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func TestRun(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Run suite")
+}

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -1,0 +1,59 @@
+package run
+
+import (
+	"context"
+	"net"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	"github.com/teslamotors/fleet-telemetry/config"
+	"github.com/teslamotors/fleet-telemetry/datastore/zmq"
+	"github.com/teslamotors/fleet-telemetry/metrics"
+	"github.com/teslamotors/fleet-telemetry/telemetry"
+)
+
+var _ = Describe("Test app shutdown", func() {
+	var (
+		conf   *config.Config
+		logger *logrus.Logger
+	)
+
+	BeforeEach(func() {
+		conf = &config.Config{
+			Host:       "127.0.0.1",
+			Port:       443,
+			StatusPort: 8080,
+			Namespace:  "tesla_telemetry",
+			TLS:        &config.TLS{CAFile: "tesla.ca", ServerCert: "your_own_cert.crt", ServerKey: "your_own_key.key"},
+			ZMQ: &zmq.Config{
+				Addr: "tcp://127.0.0.1:5284",
+			},
+			Monitoring:    &metrics.MonitoringConfig{PrometheusMetricsPort: 9090, ProfilerPort: 4269, ProfilingPath: "/tmp/fleet-telemetry/profile/"},
+			LogLevel:      "info",
+			JSONLogEnable: true,
+			Records:       map[string][]telemetry.Dispatcher{"FS": {"kafka"}},
+		}
+		logger = logrus.New()
+		conf.MetricCollector = metrics.NewCollector(conf.Monitoring, logger)
+		conf.AckChan = make(chan *telemetry.Record)
+	})
+
+	It("fails when app doesn't shutdown before timeout", func() {
+		// Run the server for 1s, then cancel it.
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		beganRunning := time.Now()
+		RunServer(ctx, conf, logger)
+		Expect(time.Since(beganRunning) > ShutdownTimeout).To(BeFalse())
+	})
+
+	It("fails when app doesn't close its producer", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		cancel()
+		RunServer(ctx, conf, logger)
+		_, err := net.Dial("tcp", "127.0.0.1:5284")
+		Expect(err).ToNot(BeNil())
+	})
+})

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -48,17 +48,8 @@ var _ = Describe("Test full application config", func() {
 
 	AfterEach(func() {
 		os.Clearenv()
-		type Closer interface {
-			Close() error
-		}
-		for _, typeProducers := range producers {
-			for _, producer := range typeProducers {
-				if closer, ok := producer.(Closer); ok {
-					err := closer.Close()
-					Expect(err).NotTo(HaveOccurred())
-				}
-			}
-		}
+		err := telemetry.CloseDispatchRules(producers)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	Context("ExtractServiceTLSConfig", func() {

--- a/datastore/googlepubsub/publisher.go
+++ b/datastore/googlepubsub/publisher.go
@@ -143,3 +143,8 @@ func registerMetrics(metricsCollector metrics.MetricCollector) {
 		Labels: []string{"record_type"},
 	})
 }
+
+// Close the underlying pubsub connection.
+func (p *Producer) Close() error {
+	return p.pubsubClient.Close()
+}

--- a/datastore/kafka/kafka.go
+++ b/datastore/kafka/kafka.go
@@ -137,3 +137,9 @@ func registerMetrics(metricsCollector metrics.MetricCollector) {
 		Labels: []string{},
 	})
 }
+
+// Close the underlying kafka producer.
+func (p *Producer) Close() error {
+	p.kafkaProducer.Close()
+	return nil
+}

--- a/datastore/kinesis/kinesis.go
+++ b/datastore/kinesis/kinesis.go
@@ -119,3 +119,8 @@ func registerMetrics(metricsCollector metrics.MetricCollector) {
 		Labels: []string{"record_type"},
 	})
 }
+
+// Close does nothing as the underlying kinesis object has no close method.
+func (p *Producer) Close() error {
+	return nil
+}

--- a/datastore/simple/logger.go
+++ b/datastore/simple/logger.go
@@ -67,3 +67,8 @@ func (p *ProtoLogger) Produce(entry *telemetry.Record) {
 		p.logger.Infof("logger_json_unmarshal %s %v %s\n", entry.Vin, entry.Metadata(), output)
 	}
 }
+
+// Close does nothing as the proto logger maintains no resources.
+func (p *ProtoLogger) Close() error {
+	return nil
+}

--- a/datastore/zmq/zmq.go
+++ b/datastore/zmq/zmq.go
@@ -80,13 +80,7 @@ func (p *ZMQProducer) Produce(rec *telemetry.Record) {
 
 // Close the underlying socket.
 func (p *ZMQProducer) Close() error {
-	if p.sock != nil {
-		if err := p.sock.Close(); err != nil {
-			return err
-		}
-	}
-	p.sock = nil
-	return nil
+	return p.sock.Close()
 }
 
 // NewProducer creates a ZMQProducer with the given config.

--- a/server/streaming/server.go
+++ b/server/streaming/server.go
@@ -137,3 +137,10 @@ func extractCertFromHeaders(ctx context.Context, r *http.Request) (*x509.Certifi
 
 	return r.TLS.PeerCertificates[nbCerts-1], nil
 }
+
+// Close releases resources managed by the server.
+func (s *Server) Close() error {
+	err := telemetry.CloseDispatchRules(s.DispatchRules)
+	s.DispatchRules = nil
+	return err
+}

--- a/telemetry/serializer_test.go
+++ b/telemetry/serializer_test.go
@@ -21,6 +21,10 @@ func (c *CallbackTester) Produce(entry *telemetry.Record) {
 	c.counter++
 }
 
+func (c *CallbackTester) Close() error {
+	return nil
+}
+
 var _ = Describe("BinarySerializer", func() {
 	DispatchKafkaGlobal := &CallbackTester{counter: 0}
 	DispatchRules := map[string][]telemetry.Producer{


### PR DESCRIPTION
# Description

Most `telemetry.Producer`s manage resources which can be cleaned up. Expose a `Close` method which allows `telemetry.Producer`s to be closed.

I have also refactored the main function to allow for:

1. Cleaning up on interrupt (move startServer to separate function)
2. Testing cleanup functionality (move startServer out of main module)

Fixes # (issue) N/A (Discussed in earlier PR)

## Type of change

Please select all options that apply to this change:

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding updates to the documentation.
- [x] I have added/updated unit tests to cover my changes.
- [x] I have added/updated integration tests to cover my changes.
