### PR TITLE
use docker compose v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,10 +51,10 @@ test-race: test
 integration: generate-certs
 	@echo "** RUNNING INTEGRATION TESTS **"
 	./test/integration/pretest.sh
-	docker-compose -p app -f docker-compose.yml build
-	docker-compose -p app -f docker-compose.yml up -d --remove-orphans
+	docker compose -p app -f docker-compose.yml build
+	docker compose -p app -f docker-compose.yml up -d --remove-orphans
 	./test/integration/test.sh
-	docker-compose -p app -f docker-compose.yml down
+	docker compose -p app -f docker-compose.yml down
 	@echo "** INTEGRATION TESTS FINISHED **"
 
 generate-certs:


### PR DESCRIPTION
# Description

The makefile is currently using docker compose v1 syntax. Switch it to v2.

`docker-compose` now becomes `docker compose`.

Learn more: https://docs.docker.com/compose/migrate/

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x]  I have performed a self-review of my code.
- [x] I have made corresponding updates to the documentation.
- [x] I have added/updated unit tests to cover my changes.
- [x] I have added/updated integration tests to cover my changes.
