### PR TITLE
logger dispatcher logs payloads in json string

### DIFF
--- a/datastore/simple/logger.go
+++ b/datastore/simple/logger.go
@@ -18,5 +18,10 @@ func NewProtoLogger(logger *logrus.Logger) telemetry.Producer {
 
 // Produce sends the data to the logger
 func (p *ProtoLogger) Produce(entry *telemetry.Record) {
-	p.logger.Infof("logger_json_unmarshal %s %v %s\n", entry.Vin, entry.Metadata(), string(entry.Payload()))
+	data, err := entry.GetJSONPayload()
+	if err != nil {
+		p.logger.Errorf("json_unmarshal_error %s %v %s\n", entry.Vin, entry.Metadata(), err.Error())
+		return
+	}
+	p.logger.Infof("logger_json_unmarshal %s %v %s\n", entry.Vin, entry.Metadata(), string(data))
 }

--- a/telemetry/record.go
+++ b/telemetry/record.go
@@ -97,6 +97,13 @@ func (record *Record) Payload() []byte {
 	return record.PayloadBytes
 }
 
+func (record *Record) GetJSONPayload() ([]byte, error) {
+	if record.transmitDecodedRecords {
+		return record.Payload(), nil
+	}
+	return record.toJSON()
+}
+
 // Raw returns the raw telemetry record
 func (record *Record) Raw() []byte {
 	return record.RawBytes

--- a/telemetry/record_test.go
+++ b/telemetry/record_test.go
@@ -266,6 +266,21 @@ var _ = Describe("Socket handler test", func() {
 			_, err := record.GetProtoMessage()
 			Expect(err).To(MatchError("no mapping for txType: badTxType"))
 		})
+
+		It("json payload returns valid data when transmitDecodedRecords is false", func() {
+			message := messages.StreamMessage{TXID: []byte("1234"), SenderID: []byte("vehicle_device.42"), MessageTopic: []byte("V"), Payload: generatePayload("cybertruck", "42", nil)}
+			recordMsg, err := message.ToBytes()
+			Expect(err).NotTo(HaveOccurred())
+
+			record, err := telemetry.NewRecord(serializer, recordMsg, "1", false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(record).NotTo(BeNil())
+
+			expectedJSON := "{\"data\":[{\"key\":\"VehicleName\",\"value\":{\"stringValue\":\"cybertruck\"}}],\"createdAt\":null,\"vin\":\"42\"}"
+			data, err := record.GetJSONPayload()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(data)).To(MatchJSON(expectedJSON))
+		})
 	})
 
 	Describe("json record", func() {
@@ -280,6 +295,10 @@ var _ = Describe("Socket handler test", func() {
 
 			expectedJSON := "{\"data\":[{\"key\":\"VehicleName\",\"value\":{\"stringValue\":\"cybertruck\"}}],\"createdAt\":null,\"vin\":\"42\"}"
 			Expect(string(record.Payload())).To(MatchJSON(expectedJSON))
+
+			data, err := record.GetJSONPayload()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(record.Payload()).To(Equal(data))
 		})
 
 		It("returns error on invalid txType", func() {


### PR DESCRIPTION
# Description

In https://github.com/teslamotors/fleet-telemetry/pull/95, logger started printed records as protobuf bytes which is not that useful. This PR ensures that always json payload is logged, regardless of value of `transmit_decoded_records`

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [X] My code follows the style of this project.
- [X] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [X] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
