### PR TITLE
Fix check_csr.sh

### DIFF
--- a/tools/check_csr.sh
+++ b/tools/check_csr.sh
@@ -41,7 +41,7 @@ match_csr() {
 
 CSR="$1"
 DN="$(openssl req -in "$1" -subject -noout)"
-HOST="$(echo $DN | sed 's/subject=[\/]*CN=//')"
+HOST="$(echo $DN | sed 's/subject=[\/]*CN\s*=\s*//')"
 
 echo "----"
 echo "CSR: $1"

--- a/tools/check_csr.sh
+++ b/tools/check_csr.sh
@@ -41,7 +41,7 @@ match_csr() {
 
 CSR="$1"
 DN="$(openssl req -in "$1" -subject -noout)"
-HOST="$(echo $DN | sed 's/subject=[\/]*CN\s*=\s*//')"
+HOST="$(echo $DN | sed 's/subject=[\/]*CN[[:space:]]*=[[:space:]]*//')"
 
 echo "----"
 echo "CSR: $1"


### PR DESCRIPTION
# Description

Fix the check_csr.sh script to allow whitespace on either side of the equals.

Fixes # (issue)

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
