### PR TITLE
callout fleet_telemetry_errors endpoint in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ Register a publicly available endpoint (DNS record) to receive device connection
 
 See https://developer.tesla.com/docs/fleet-api#setup for setting up and registering a developer account. [check_csr.sh](tools/check_csr.sh) can be used to validate CSR submissions and ensure the account's public key is available.
 
-Configure vehicles for streaming using FleetAPI's [fleet-telemetry-config](https://developer.tesla.com/docs/fleet-api#fleet_telemetry_config).  Validate vehicle configs are compatible with your server by running [check_server_cert.sh](tools/check_server_cert.sh) passing the path of your proposed vehicle config:
+Configure vehicles for streaming using FleetAPI's [fleet-telemetry-config](https://developer.tesla.com/docs/fleet-api#fleet_telemetry_config-create).  Validate vehicle configs are compatible with your server by running [check_server_cert.sh](tools/check_server_cert.sh) passing the path of your proposed vehicle config:
 ```
 ./tools/check_server_cert.sh /tmp/proposed_config.json
 ```
+
+To troubleshoot issues receiving data from vehicles, see the [fleet_telemetry_errors](https://developer.tesla.com/docs/fleet-api#fleet_telemetry_errors) endpoint.
 
 ### Install on Kubernetes with Helm Chart (recommended)
 For ease of installation and operation, run Fleet Telemetry on Kubernetes or a similar environment. Helm Charts help define, install, and upgrade applications on Kubernetes. A reference helm chart is available [here](https://github.com/teslamotors/helm-charts/blob/main/charts/fleet-telemetry/README.md).


### PR DESCRIPTION
# Description

Adding reference to fleet_telemetry_errors endpoint.

Also fixed broken link to fleet_telemetry_config create endpoint.


## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [ ] My code follows the style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
