### PR TITLE
disallow setting custom CA outside integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ For ease of installation and operation, run Fleet Telemetry on Kubernetes or a s
         "kafka"
     ]
   },
-  "tls": { // Note: setting a ca_file here can be used for testing, but may reject vehicle mTLS connections
+  "tls": {
     "server_cert": string - server cert location,
     "server_key": string - server key location
   }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -57,7 +57,7 @@ func startServer(config *config.Config, logger *logrus.Logger) (err error) {
 		return err
 	}
 
-	if server.TLSConfig, err = config.ExtractServiceTLSConfig(); err != nil {
+	if server.TLSConfig, err = config.ExtractServiceTLSConfig(logger); err != nil {
 		return err
 	}
 	return server.ListenAndServeTLS(config.TLS.ServerCert, config.TLS.ServerKey)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       AWS_ACCESS_KEY_ID: ABC123
       AWS_SECRET_ACCESS_KEY: EFG456
       PUBSUB_EMULATOR_HOST: pubsub:8085
+      # Dont set this environment variable when running this service in production
+      INTEGRATION_TEST: true
     depends_on:
       kinesis:
         condition: service_healthy


### PR DESCRIPTION
# Description

Earlier we had documentation which recommended to not set custom CA file. This PR enforces the restriction outside of integration tests

Fixes # (issue)

## Type of change

Please select all options that apply to this change:

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding updates to the documentation.
- [x] I have added/updated unit tests to cover my changes.
- [x] I have added/updated integration tests to cover my changes.
