### PR TITLE
Integrate airbrake with datastore

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -54,7 +54,7 @@ func startServer(config *config.Config, logger *logrus.Logger) (err error) {
 		monitoring.StartServerMetrics(config, logger, registry)
 	}
 
-	producerRules, err := config.ConfigureProducers(logger)
+	producerRules, err := config.ConfigureProducers(airbrakeHandler, logger)
 	if err != nil {
 		return err
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,6 +12,7 @@ import (
 
 	logrus "github.com/teslamotors/fleet-telemetry/logger"
 	"github.com/teslamotors/fleet-telemetry/metrics"
+	"github.com/teslamotors/fleet-telemetry/server/airbrake"
 	"github.com/teslamotors/fleet-telemetry/telemetry"
 )
 
@@ -134,7 +135,7 @@ var _ = Describe("Test full application config", func() {
 			config, err := loadTestApplicationConfig(TestSmallConfig)
 			Expect(err).NotTo(HaveOccurred())
 
-			producers, err = config.ConfigureProducers(log)
+			producers, err = config.ConfigureProducers(airbrake.NewAirbrakeHandler(nil), log)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(producers["FS"]).To(HaveLen(1))
 
@@ -150,7 +151,7 @@ var _ = Describe("Test full application config", func() {
 			config.Records = map[string][]telemetry.Dispatcher{"FS": {"kinesis"}}
 
 			var err error
-			producers, err = config.ConfigureProducers(log)
+			producers, err = config.ConfigureProducers(airbrake.NewAirbrakeHandler(nil), log)
 			Expect(err).To(MatchError("Expected Kinesis to be configured"))
 			Expect(producers).To(BeNil())
 		})
@@ -188,7 +189,7 @@ var _ = Describe("Test full application config", func() {
 			log, _ := logrus.NoOpLogger()
 			_ = os.Setenv("PUBSUB_EMULATOR_HOST", "some_url")
 			_ = os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "some_service_account_path")
-			_, err := pubsubConfig.ConfigureProducers(log)
+			_, err := pubsubConfig.ConfigureProducers(airbrake.NewAirbrakeHandler(nil), log)
 			Expect(err).To(MatchError("pubsub_connect_error pubsub cannot initialize with both emulator and GCP resource"))
 		})
 
@@ -196,7 +197,7 @@ var _ = Describe("Test full application config", func() {
 			log, _ := logrus.NoOpLogger()
 			_ = os.Setenv("PUBSUB_EMULATOR_HOST", "some_url")
 			var err error
-			producers, err = pubsubConfig.ConfigureProducers(log)
+			producers, err = pubsubConfig.ConfigureProducers(airbrake.NewAirbrakeHandler(nil), log)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(producers["FS"]).NotTo(BeNil())
 		})
@@ -215,10 +216,10 @@ var _ = Describe("Test full application config", func() {
 			log, _ := logrus.NoOpLogger()
 			config.Records = map[string][]telemetry.Dispatcher{"FS": {"zmq"}}
 			var err error
-			producers, err = config.ConfigureProducers(log)
+			producers, err = config.ConfigureProducers(airbrake.NewAirbrakeHandler(nil), log)
 			Expect(err).To(MatchError("Expected ZMQ to be configured"))
 			Expect(producers).To(BeNil())
-			producers, err = zmqConfig.ConfigureProducers(log)
+			producers, err = zmqConfig.ConfigureProducers(airbrake.NewAirbrakeHandler(nil), log)
 			Expect(err).To(BeNil())
 		})
 
@@ -227,7 +228,7 @@ var _ = Describe("Test full application config", func() {
 			zmqConfig.ZMQ.Addr = "tcp://127.0.0.1:5285"
 			log, _ := logrus.NoOpLogger()
 			var err error
-			producers, err = zmqConfig.ConfigureProducers(log)
+			producers, err = zmqConfig.ConfigureProducers(airbrake.NewAirbrakeHandler(nil), log)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(producers["FS"]).NotTo(BeNil())
 		})

--- a/datastore/googlepubsub/publisher.go
+++ b/datastore/googlepubsub/publisher.go
@@ -13,6 +13,7 @@ import (
 	logrus "github.com/teslamotors/fleet-telemetry/logger"
 	"github.com/teslamotors/fleet-telemetry/metrics"
 	"github.com/teslamotors/fleet-telemetry/metrics/adapter"
+	"github.com/teslamotors/fleet-telemetry/server/airbrake"
 	"github.com/teslamotors/fleet-telemetry/telemetry"
 )
 
@@ -24,6 +25,7 @@ type Producer struct {
 	metricsCollector  metrics.MetricCollector
 	prometheusEnabled bool
 	logger            *logrus.Logger
+	airbrakeHandler   *airbrake.AirbrakeHandler
 }
 
 // Metrics stores metrics reported from this package
@@ -52,7 +54,7 @@ func configurePubsub(projectID string) (*pubsub.Client, error) {
 }
 
 // NewProducer establishes the pubsub connection and define the dispatch method
-func NewProducer(ctx context.Context, prometheusEnabled bool, projectID string, namespace string, metricsCollector metrics.MetricCollector, logger *logrus.Logger) (telemetry.Producer, error) {
+func NewProducer(ctx context.Context, prometheusEnabled bool, projectID string, namespace string, metricsCollector metrics.MetricCollector, airbrakeHandler *airbrake.AirbrakeHandler, logger *logrus.Logger) (telemetry.Producer, error) {
 	registerMetricsOnce(metricsCollector)
 	pubsubClient, err := configurePubsub(projectID)
 	if err != nil {
@@ -66,6 +68,7 @@ func NewProducer(ctx context.Context, prometheusEnabled bool, projectID string, 
 		prometheusEnabled: prometheusEnabled,
 		metricsCollector:  metricsCollector,
 		logger:            logger,
+		airbrakeHandler:   airbrakeHandler,
 	}
 	p.logger.ActivityLog("pubsub_registerd", logrus.LogInfo{"project": projectID, "namespace": namespace})
 	return p, nil
@@ -80,13 +83,13 @@ func (p *Producer) Produce(entry *telemetry.Record) {
 	pubsubTopic, err := p.createTopicIfNotExists(ctx, topicName)
 
 	if err != nil {
-		p.logger.ErrorLog("pubsub_topic_creation_error", err, logInfo)
+		p.ReportError("pubsub_topic_creation_error", err, logInfo)
 		metricsRegistry.notConnectedTotal.Inc(map[string]string{})
 		return
 	}
 
 	if exists, err := pubsubTopic.Exists(ctx); !exists || err != nil {
-		p.logger.ErrorLog("pubsub_topic_check_error", err, logInfo)
+		p.ReportError("pubsub_topic_check_error", err, logInfo)
 		metricsRegistry.notConnectedTotal.Inc(map[string]string{})
 		return
 	}
@@ -97,7 +100,7 @@ func (p *Producer) Produce(entry *telemetry.Record) {
 		Attributes: entry.Metadata(),
 	})
 	if _, err = result.Get(ctx); err != nil {
-		p.logger.ErrorLog("pubsub_err", err, logInfo)
+		p.ReportError("pubsub_err", err, logInfo)
 		metricsRegistry.errorCount.Inc(map[string]string{"record_type": entry.TxType})
 		return
 	}
@@ -117,6 +120,12 @@ func (p *Producer) createTopicIfNotExists(ctx context.Context, topic string) (*p
 	}
 
 	return p.pubsubClient.CreateTopic(ctx, topic)
+}
+
+// ReportError to airbrake and logger
+func (p *Producer) ReportError(message string, err error, logInfo logrus.LogInfo) {
+	p.airbrakeHandler.ReportLogMessage(logrus.ERROR, message, err, logInfo)
+	p.logger.ErrorLog(message, err, logInfo)
 }
 
 func registerMetricsOnce(metricsCollector metrics.MetricCollector) {

--- a/datastore/simple/logger.go
+++ b/datastore/simple/logger.go
@@ -24,3 +24,8 @@ func (p *ProtoLogger) Produce(entry *telemetry.Record) {
 	}
 	p.logger.ActivityLog("logger_json_unmarshal", logrus.LogInfo{"vin": entry.Vin, "metadata": entry.Metadata(), "data": string(data)})
 }
+
+// ReportError noop method
+func (p *ProtoLogger) ReportError(message string, err error, logInfo logrus.LogInfo) {
+	return
+}

--- a/telemetry/producer.go
+++ b/telemetry/producer.go
@@ -2,6 +2,8 @@ package telemetry
 
 import (
 	"fmt"
+
+	logrus "github.com/teslamotors/fleet-telemetry/logger"
 )
 
 // Dispatcher type of telemetry record dispatcher
@@ -28,4 +30,5 @@ func BuildTopicName(namespace, recordName string) string {
 // Producer handles dispatching data received from the vehicle
 type Producer interface {
 	Produce(entry *Record)
+	ReportError(message string, err error, logInfo logrus.LogInfo)
 }


### PR DESCRIPTION
# Description

Report datastore errors to airbrake. Note that it will only dispatch errors to airbrake if its actually configured otherwise `func (a *AirbrakeHandler) ReportLogMessage` acts as a noop.

Fixes # (issue)

## Type of change

Please select all options that apply to this change:

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [X] My code follows the style of this project.
- [X] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [X] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
