### PR TITLE
Add airbrake project key environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ Data is encapsulated into protobuf messages of different types. Protos can be re
   ```sh
   make generate-protos
   ```
+## Airbrake
+Fleet telemetry allows you to monitor errors using [airbrake](https://www.airbrake.io/error-monitoring). The integration test runs fleet telemetry with [errbit](https://github.com/errbit/errbit), which is an airbrake compliant self-hosted error catcher. You can set a project key for airbrake using either the config file or via an environment variable `AIRBRAKE_PROJECT_KEY`. 
 
 # Testing
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,7 +41,7 @@ func startServer(config *config.Config, logger *logrus.Logger) (err error) {
 	logger.ActivityLog("starting_server", nil)
 	registry := streaming.NewSocketRegistry()
 
-	airbrakeNotifier, err := config.CreateAirbrakeNotifier()
+	airbrakeNotifier, _, err := config.CreateAirbrakeNotifier(logger)
 	if err != nil {
 		return err
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -145,6 +145,29 @@ var _ = Describe("Test full application config", func() {
 		})
 	})
 
+	Context("configure airbrake", func() {
+		It("gets config from file", func() {
+			config, err := loadTestApplicationConfig(TestAirbrakeConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, options, err := config.CreateAirbrakeNotifier(log)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(options.ProjectKey).To(Equal("test1"))
+		})
+
+		It("gets config from env variable", func() {
+			projectKey := "environmentProjectKey"
+			err := os.Setenv("AIRBRAKE_PROJECT_KEY", projectKey)
+			Expect(err).NotTo(HaveOccurred())
+			config, err := loadTestApplicationConfig(TestAirbrakeConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, options, err := config.CreateAirbrakeNotifier(log)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(options.ProjectKey).To(Equal(projectKey))
+		})
+	})
+
 	Context("configure kinesis", func() {
 		It("returns an error if kinesis isn't included", func() {
 			log, _ := logrus.NoOpLogger()
@@ -179,10 +202,6 @@ var _ = Describe("Test full application config", func() {
 			var err error
 			pubsubConfig, err = loadTestApplicationConfig(TestPubsubConfig)
 			Expect(err).NotTo(HaveOccurred())
-		})
-
-		AfterEach(func() {
-			os.Clearenv()
 		})
 
 		It("pubsub does not work when both the environment variables are set", func() {

--- a/config/test_configs_test.go
+++ b/config/test_configs_test.go
@@ -107,3 +107,33 @@ const TestTransmitDecodedRecords = `
 	}
 }
 `
+
+const TestAirbrakeConfig = `
+{
+	"host": "127.0.0.1",
+	"port": 443,
+	"status_port": 8080,
+	"namespace": "tesla_telemetry",
+	"kafka": {
+		"bootstrap.servers": "some.broker1:9093,some.broker1:9093",
+		"ssl.ca.location": "kafka.ca",
+		"ssl.certificate.location": "kafka.crt",
+		"ssl.key.location": "kafka.key",
+		"queue.buffering.max.messages": 1000000
+	},
+	"records": {
+		"FS": ["kafka"]
+	},
+	"tls": {
+		"ca_file": "tesla.ca",
+		"server_cert": "your_own_cert.crt",
+		"server_key": "your_own_key.key"
+	},
+	"airbrake": {
+        "project_id": 1,
+        "project_key": "test1",
+        "environment": "integration",
+        "host": "http://errbit-test.example.com"
+    }
+}
+`


### PR DESCRIPTION
# Description

Allow setting `AIRBRAKE_API_KEY` environment variable so that key can be avoided being stored in plaintext. If the env variable is set, it will override whatever is stored in Airbrake.ProjectId field of config file.

## Type of change

Please select all options that apply to this change:

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [X] My code follows the style of this project.
- [X] I have performed a self-review of my code.
- [X] I have made corresponding updates to the documentation.
- [X] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
