### PR TITLE
Fix airbrake notice message

### DIFF
--- a/server/airbrake/airbrake_test.go
+++ b/server/airbrake/airbrake_test.go
@@ -1,35 +1,37 @@
 package airbrake
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	logrus "github.com/teslamotors/fleet-telemetry/logger"
 )
 
 var _ = Describe("AirbrakeMiddleware", func() {
 	var (
-		middleware *AirbrakeHandler
-		recorder   *httptest.ResponseRecorder
-		req        *http.Request
+		handler  *AirbrakeHandler
+		recorder *httptest.ResponseRecorder
+		req      *http.Request
 	)
 
 	BeforeEach(func() {
 		var err error
 		req, err = http.NewRequest("GET", "/test", nil)
 		Expect(err).NotTo(HaveOccurred())
-		middleware = NewAirbrakeHandler(nil)
+		handler = NewAirbrakeHandler(nil)
 		recorder = httptest.NewRecorder()
 	})
 
 	DescribeTable("successfully handles request",
 		func(statusCode int, body string) {
-			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			httpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(statusCode)
 				w.Write([]byte(body))
 			})
-			middleware.WithReporting(handler).ServeHTTP(recorder, req)
+			handler.WithReporting(httpHandler).ServeHTTP(recorder, req)
 			Expect(recorder.Code).To(Equal(statusCode))
 			responseBody := recorder.Body.Bytes()
 			Expect(responseBody).To(Equal([]byte(body)))
@@ -38,4 +40,29 @@ var _ = Describe("AirbrakeMiddleware", func() {
 		Entry("400", http.StatusInternalServerError, "bad error"),
 		Entry("200", http.StatusOK, "ok"),
 	)
+
+	Context("logMessage", func() {
+
+		It("for error", func() {
+			notice := handler.logMessage(logrus.ERROR, "test_err", errors.New("sample error"), logrus.LogInfo{"key1": "value1", "key2": "value2"})
+			Expect(len(notice.Errors)).Should(Equal(1))
+			Expect(notice.Errors[0].Message).Should(Equal("test_err"))
+			Expect(notice.Params).Should(Equal(map[string]interface{}{"log_type": "error", "error": "sample error", "key1": "value1", "key2": "value2"}))
+		})
+
+		It("for error with logInfo", func() {
+			notice := handler.logMessage(logrus.ERROR, "test_err", errors.New("sample error"), nil)
+			Expect(len(notice.Errors)).Should(Equal(1))
+			Expect(notice.Errors[0].Message).Should(Equal("test_err"))
+			Expect(notice.Params).Should(Equal(map[string]interface{}{"log_type": "error", "error": "sample error"}))
+		})
+
+		It("for info", func() {
+			notice := handler.logMessage(logrus.INFO, "test_info", nil, logrus.LogInfo{"key1": "value1", "key2": "value2"})
+			Expect(len(notice.Errors)).Should(Equal(1))
+			Expect(notice.Errors[0].Message).Should(Equal("test_info"))
+			Expect(notice.Params).Should(Equal(map[string]interface{}{"log_type": "info", "key1": "value1", "key2": "value2"}))
+		})
+	})
+
 })


### PR DESCRIPTION
# Description
Errbit logs error like this
<img width="761" alt="Screenshot 2024-04-08 at 13 31 49" src="https://github.com/teslamotors/fleet-telemetry/assets/8400714/1922414c-8001-4f3f-b95f-372fa08d0808">
This format isn't useful. Making following changes
- `logType` is int. `logrus.AllLogType[logType]` will return value in string
- `err.Error()` extracts error message to be logged properly in airbrake


## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [X] My code follows the style of this project.
- [X] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [X] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
