### PR TITLE
Remove storing of unused attributes

### DIFF
--- a/telemetry/record.go
+++ b/telemetry/record.go
@@ -51,7 +51,6 @@ type Record struct {
 	Version                int
 	Vin                    string
 	PayloadBytes           []byte
-	RawBytes               []byte
 	transmitDecodedRecords bool
 }
 
@@ -98,6 +97,11 @@ func (record *Record) Payload() []byte {
 	return record.PayloadBytes
 }
 
+// Length returns the length of payload
+func (record *Record) Length() int {
+	return len(record.PayloadBytes)
+}
+
 func (record *Record) GetJSONPayload() ([]byte, error) {
 	if record.transmitDecodedRecords {
 		return record.Payload(), nil
@@ -105,34 +109,11 @@ func (record *Record) GetJSONPayload() ([]byte, error) {
 	return record.toJSON()
 }
 
-// Raw returns the raw telemetry record
-func (record *Record) Raw() []byte {
-	return record.RawBytes
-}
-
-// Length gets the records byte size
-func (record *Record) Length() int {
-	record.ensureEncoded()
-	return len(record.RawBytes)
-}
-
-// Encode encodes the records into bytes
-func (record *Record) Encode() ([]byte, error) {
-	record.ensureEncoded()
-	return record.RawBytes, nil
-}
-
 // Dispatch uses the configuration to send records to the list of backends/data stores they belong
 func (record *Record) Dispatch() {
 	logger := record.Serializer.Logger()
-	logger.Log(logrus.DEBUG, "dispatching_message", logrus.LogInfo{"socket_id": record.SocketID, "payload": record.Raw()})
+	logger.Log(logrus.DEBUG, "dispatching_message", logrus.LogInfo{"socket_id": record.SocketID, "payload": record.Payload()})
 	record.Serializer.Dispatch(record)
-}
-
-func (record *Record) ensureEncoded() {
-	if record.RawBytes == nil && record.Serializer != nil && record.Serializer.Logger() != nil {
-		record.Serializer.Logger().ErrorLog("record_RawBytes_blank", nil, nil)
-	}
 }
 
 func (record *Record) applyProtoRecordTransforms() error {

--- a/telemetry/serializer.go
+++ b/telemetry/serializer.go
@@ -42,17 +42,13 @@ func (bs *BinarySerializer) Deserialize(msg []byte, socketID string) (record *Re
 		}
 	}()
 
-	record = &Record{Serializer: bs, RawBytes: msg, SocketID: socketID}
+	record = &Record{Serializer: bs, SocketID: socketID}
 	streamMessage, err := messages.StreamMessageFromBytes(msg)
 	if err != nil {
 		return record, bs.guessError(record, msg)
 	}
 
 	streamMessage.SetDeliveredAt(time.Now())
-	record.RawBytes, err = streamMessage.ToBytes()
-	if err != nil {
-		bs.logger.ErrorLog("set_delivered_at_bytes_error", err, logrus.LogInfo{"record_type": record.TxType, "txid": record.Txid})
-	}
 
 	record.TxType = streamMessage.Topic()
 	record.Txid = string(streamMessage.TXID)

--- a/telemetry/serializer_test.go
+++ b/telemetry/serializer_test.go
@@ -2,7 +2,6 @@ package telemetry_test
 
 import (
 	"errors"
-	"reflect"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -74,7 +73,6 @@ var _ = Describe("BinarySerializer", func() {
 			},
 			wantRecord: &telemetry.Record{
 				Serializer: nil,
-				RawBytes:   nil,
 				TxType:     "T",
 				Txid:       "test-42",
 				SocketID:   "Socket-42",
@@ -95,7 +93,6 @@ var _ = Describe("BinarySerializer", func() {
 			},
 			wantRecord: &telemetry.Record{
 				Serializer: nil,
-				RawBytes:   nil,
 				TxType:     "T",
 				Txid:       "test-42",
 				SocketID:   "Socket-42",
@@ -122,7 +119,6 @@ var _ = Describe("BinarySerializer", func() {
 			},
 			wantRecord: &telemetry.Record{
 				Serializer: nil,
-				RawBytes:   nil,
 				TxType:     "T1",
 				Txid:       "test-42",
 				SocketID:   "Socket-42",
@@ -149,7 +145,6 @@ var _ = Describe("BinarySerializer", func() {
 			},
 			wantRecord: &telemetry.Record{
 				Serializer: nil,
-				RawBytes:   nil,
 				TxType:     "T1",
 				Txid:       "test-42",
 				SocketID:   "Socket-42",
@@ -173,10 +168,7 @@ var _ = Describe("BinarySerializer", func() {
 
 			gotRecord.ReceivedTimestamp = 0
 			tt.wantRecord.Serializer = bs
-			Expect(gotRecord.RawBytes).NotTo(BeEmpty())
-			Expect(reflect.DeepEqual(gotRecord.RawBytes, msgBytes)).To(BeFalse())
 
-			tt.wantRecord.RawBytes = gotRecord.RawBytes
 			tt.wantRecord.PayloadBytes = gotRecord.PayloadBytes
 
 			Expect(gotRecord).To(Equal(tt.wantRecord))


### PR DESCRIPTION
# Description
This PR removes storing of rawBytes for few reasons:-
- Datastore sends `Payload` and not `RawBytes` from the vehicle. 
- Our metrics for datastore were instrumented against length rawRawBytes when in reality we send `Payload` to them
-`streamMessage.ToBytes()` was doing unnecessary flatbuffer to bytes transformation which the server doesn't really need
- Removing unused helper methods around `RawBytes` like `Encode`, `ensureEncoded`

## Type of change

Please select all options that apply to this change:

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [X] My code follows the style of this project.
- [X] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [X] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
