### PR TITLE
Fix metrics for dispatched record size

### DIFF
--- a/telemetry/record.go
+++ b/telemetry/record.go
@@ -110,10 +110,15 @@ func (record *Record) Raw() []byte {
 	return record.RawBytes
 }
 
-// Length gets the records byte size
-func (record *Record) Length() int {
+// Length gets the records flatbuffer payload byte size
+func (record *Record) LengthRawBytes() int {
 	record.ensureEncoded()
 	return len(record.RawBytes)
+}
+
+// Length gets the records byte size
+func (record *Record) Length() int {
+	return len(record.PayloadBytes)
 }
 
 // Encode encodes the records into bytes


### PR DESCRIPTION
# Description

In datastore, we use [Length()](https://github.com/teslamotors/fleet-telemetry/blob/main/datastore/kafka/kafka.go#L91) to instrument payload size sent to them. However the value which was instrumented was the flatbuffer message. Fixing here to use the actual payload length

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [X] My code follows the style of this project.
- [X] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
