### PR TITLE
Add support to suppress tls logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ Configure and use Prometheus or a StatsD-interface supporting data store for met
 
 ![Basic Dashboard](./doc/grafana-dashboard.png)
 
+## Logging
+
+To suppress [tls handshake error logging](https://cs.opensource.google/go/go/+/master:src/net/http/server.go;l=1933?q=%22TLS%20handshake%20error%20from%20%22&ss=go%2Fgo), set environment variable `SUPPRESS_TLS_HANDSHAKE_ERROR_LOGGING` to `true`. See [docker compose](./docker-compose.yml) for example.
+
 ## Protos
 Data is encapsulated into protobuf messages of different types. Protos can be recompiled via:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       AWS_ACCESS_KEY_ID: ABC123
       AWS_SECRET_ACCESS_KEY: EFG456
       PUBSUB_EMULATOR_HOST: pubsub:8085
+      SUPPRESS_TLS_HANDSHAKE_ERROR_LOGGING: true
     depends_on:
       kinesis:
         condition: service_healthy

--- a/logger/logger_logrus_test.go
+++ b/logger/logger_logrus_test.go
@@ -2,6 +2,7 @@ package logrus
 
 import (
 	"errors"
+	"os"
 
 	githubLogrus "github.com/sirupsen/logrus"
 
@@ -10,29 +11,58 @@ import (
 )
 
 var _ = Describe("logger tests", func() {
+
+	BeforeEach(func() {
+		os.Clearenv()
+	})
+
 	It("works", func() {
 		data := map[string]interface{}{"simple": "value", "complex": `has "quotes" and spaces`, "boolean": true}
 
 		logger, hook := NoOpLogger()
 
 		logger.Log(INFO, "http", data)
-		Expect(len(hook.Entries)).To(Equal(1))
+		Expect(hook.Entries).To(HaveLen(1))
 		Expect(hook.LastEntry().Level).To(Equal(githubLogrus.InfoLevel))
 		Expect(hook.LastEntry().Message).To(Equal("http"))
 
 		logger.ActivityLog("sample_activity_log", data)
-		Expect(len(hook.Entries)).To(Equal(2))
+		Expect(hook.Entries).To(HaveLen(2))
 		Expect(hook.LastEntry().Level).To(Equal(githubLogrus.InfoLevel))
 		Expect(hook.LastEntry().Message).To(Equal("sample_activity_log"))
 
-		logger.AnomalyLog("sample_anomaly_log", data)
-		Expect(len(hook.Entries)).To(Equal(3))
+		logger.ErrorLog("sample_anomaly_log", nil, data)
+		Expect(hook.Entries).To(HaveLen(3))
 		Expect(hook.LastEntry().Level).To(Equal(githubLogrus.ErrorLevel))
 		Expect(hook.LastEntry().Message).To(Equal("sample_anomaly_log"))
 
-		logger.AnomalyLogError("sample_anomaly_log_2", errors.New("error message"), nil)
-		Expect(len(hook.Entries)).To(Equal(4))
+		logger.ErrorLog("sample_anomaly_log_2", errors.New("error message"), nil)
+		Expect(hook.Entries).To(HaveLen(4))
 		Expect(hook.LastEntry().Level).To(Equal(githubLogrus.ErrorLevel))
 		Expect(hook.LastEntry().Message).To(Equal("sample_anomaly_log_2"))
+
+		logger.Log(ERROR, "http: TLS handshake error from 0.0.0.0:1: EOF", nil)
+		Expect(hook.Entries).To(HaveLen(5))
+		Expect(hook.LastEntry().Level).To(Equal(githubLogrus.ErrorLevel))
+		Expect(hook.LastEntry().Message).To(Equal("http: TLS handshake error from 0.0.0.0:1: EOF"))
 	})
+
+	Context("Tls handshake error", func() {
+		DescribeTable("suppresses",
+			func(envValue string) {
+				os.Setenv("SUPPRESS_TLS_HANDSHAKE_ERROR_LOGGING", envValue)
+				logger, hook := NoOpLogger()
+				logger.Log(ERROR, "http: TLS handshake error from 0.0.0.0:1: EOF", nil)
+				Expect(hook.Entries).To(BeEmpty())
+				logger.Log(ERROR, "Random error", nil)
+				Expect(hook.Entries).To(HaveLen(1))
+				Expect(hook.LastEntry().Message).To(Equal("Random error"))
+
+			},
+			Entry("for env variable true", "true"),
+			Entry("for env variable TRUE", "TRUE"),
+			Entry("for env variable 1", "1"),
+		)
+	})
+
 })

--- a/logger/no_op_logger.go
+++ b/logger/no_op_logger.go
@@ -6,5 +6,6 @@ import (
 
 func NoOpLogger() (*Logger, *test.Hook) {
 	log, hook := test.NewNullLogger()
-	return NewLogrusLogger("null_logger", map[string]interface{}{}, log.WithField("context", "test")), hook
+	logger, _ := NewLogrusLogger("null_logger", map[string]interface{}{}, log.WithField("context", "test"))
+	return logger, hook
 }


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue.


## Type of change

Key changes:-
- Allow a way to suppress the logging messages related to tls handshake error logged [here](https://cs.opensource.google/go/go/+/master:src/net/http/server.go;l=1933?q=%22TLS%20handshake%20error%20from%20%22&ss=go%2Fgo).
- Remove unused anomaly logger method

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [X] My code follows the style of this project.
- [X] I have performed a self-review of my code.
- [X] I have made corresponding updates to the documentation.
- [X] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
