### PR TITLE
Use delivery channel to get kafka producer metrics

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -245,6 +245,10 @@ func (c *Config) prometheusEnabled() bool {
 	return false
 }
 
+func (c *Config) ReliableAcksDisabled() bool {
+	return c.ReliableAck == false && c.ReliableAckWorkers == 0
+}
+
 // ConfigureProducers validates and establishes connections to the producers (kafka/pubsub/logger)
 func (c *Config) ConfigureProducers(airbrakeHandler *airbrake.AirbrakeHandler, logger *logrus.Logger) (map[string][]telemetry.Producer, error) {
 	producers := make(map[telemetry.Dispatcher]telemetry.Producer)
@@ -262,7 +266,7 @@ func (c *Config) ConfigureProducers(airbrakeHandler *airbrake.AirbrakeHandler, l
 			return nil, errors.New("Expected Kafka to be configured")
 		}
 		convertKafkaConfig(c.Kafka)
-		kafkaProducer, err := kafka.NewProducer(c.Kafka, c.Namespace, c.ReliableAckWorkers, c.AckChan, c.prometheusEnabled(), c.MetricCollector, airbrakeHandler, logger)
+		kafkaProducer, err := kafka.NewProducer(c.Kafka, c.Namespace, c.prometheusEnabled(), c.MetricCollector, airbrakeHandler, logger)
 		if err != nil {
 			return nil, err
 		}

--- a/config/config_initializer.go
+++ b/config/config_initializer.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"log"
 	"os"
@@ -54,6 +55,10 @@ func loadApplicationConfig(configFilePath string) (*Config, error) {
 	}
 	config.MetricCollector = metrics.NewCollector(config.Monitoring, logger)
 
+	// TODO disble this check when reliable acks are properly supported
+	if !config.ReliableAcksDisabled() {
+		return nil, errors.New("reliable acks not support yet. Unset `reliable_ack` and `reliable_ack_workers` in the config file")
+	}
 	config.AckChan = make(chan *telemetry.Record)
 	return config, err
 }

--- a/config/config_initializer_test.go
+++ b/config/config_initializer_test.go
@@ -23,8 +23,8 @@ var _ = Describe("Test application config initialization", func() {
 			Namespace:          "tesla_telemetry",
 			TLS:                &TLS{CAFile: "tesla.ca", ServerCert: "your_own_cert.crt", ServerKey: "your_own_key.key"},
 			RateLimit:          &RateLimit{Enabled: true, MessageLimit: 1000, MessageInterval: 30},
-			ReliableAck:        true,
-			ReliableAckWorkers: 15,
+			ReliableAck:        false,
+			ReliableAckWorkers: 0,
 			Kafka: &confluent.ConfigMap{
 				"bootstrap.servers":            "some.broker1:9093,some.broker1:9093",
 				"ssl.ca.location":              "kafka.ca",
@@ -71,6 +71,11 @@ var _ = Describe("Test application config initialization", func() {
 		expectedConfig.MetricCollector = loadedConfig.MetricCollector
 		expectedConfig.AckChan = loadedConfig.AckChan
 		Expect(loadedConfig).To(Equal(expectedConfig))
+	})
+
+	It("fails when reliable acks are set", func() {
+		_, err := loadTestApplicationConfig(TestReliableAckConfig)
+		Expect(err).Should(MatchError("reliable acks not support yet. Unset `reliable_ack` and `reliable_ack_workers` in the config file"))
 	})
 
 	It("returns an error if config is not appropriate", func() {

--- a/config/test_configs_test.go
+++ b/config/test_configs_test.go
@@ -7,8 +7,6 @@ const TestConfig = `{
 	"log_level": "info",
 	"json_log_enable": true,
 	"namespace": "tesla_telemetry",
-	"reliable_ack": true,
-	"reliable_ack_workers": 15,
 	"kafka": {
 		"bootstrap.servers": "some.broker1:9093,some.broker1:9093",
 		"ssl.ca.location": "kafka.ca",
@@ -43,6 +41,32 @@ const TestSmallConfig = `
 	"port": 443,
 	"status_port": 8080,
 	"namespace": "tesla_telemetry",
+	"kafka": {
+		"bootstrap.servers": "some.broker1:9093,some.broker1:9093",
+		"ssl.ca.location": "kafka.ca",
+		"ssl.certificate.location": "kafka.crt",
+		"ssl.key.location": "kafka.key",
+		"queue.buffering.max.messages": 1000000
+	},
+	"records": {
+		"FS": ["kafka"]
+	},
+	"tls": {
+		"ca_file": "tesla.ca",
+		"server_cert": "your_own_cert.crt",
+		"server_key": "your_own_key.key"
+	}
+}
+`
+
+const TestReliableAckConfig = `
+{
+	"host": "127.0.0.1",
+	"port": 443,
+	"status_port": 8080,
+	"namespace": "tesla_telemetry",
+	"reliable_ack": true,
+	"reliable_ack_workers": 15,
 	"kafka": {
 		"bootstrap.servers": "some.broker1:9093,some.broker1:9093",
 		"ssl.ca.location": "kafka.ca",

--- a/test/integration/config.json
+++ b/test/integration/config.json
@@ -5,8 +5,6 @@
     "log_level": "info",
     "json_log_enable": true,
     "namespace": "tesla_telemetry",
-    "reliable_ack": true,
-    "reliable_ack_workers": 15,
     "kafka": {
         "bootstrap.servers": "kafka:9092",
         "queue.buffering.max.messages": 1000000,


### PR DESCRIPTION
# Description
Confluent provides the channel interface to get delivery reports. We should use that to get kafka metrics

## Type of change

Please select all options that apply to this change:

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [X] My code follows the style of this project.
- [X] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
