### PR TITLE
Add ability to disable mTLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,3 +272,4 @@ Moreover, the following application-specific considerations apply:
   the frequency they need.
 * Providers agree to take full responsibility for privacy risks, as soon as data
   leave the devices (for more info read our privacy policies).
+* If (and only if!) your're running your Fleet Telemetry instance behind a reverse proxy which takes care of mTLS handling, set ```"disable_tls"``` to ```true``` in the config.

--- a/README.md
+++ b/README.md
@@ -272,4 +272,4 @@ Moreover, the following application-specific considerations apply:
   the frequency they need.
 * Providers agree to take full responsibility for privacy risks, as soon as data
   leave the devices (for more info read our privacy policies).
-* If (and only if!) your're running your Fleet Telemetry instance behind a reverse proxy which takes care of mTLS handling, set ```"disable_tls"``` to ```true``` in the config.
+* If (and only if!) your're running your Fleet Telemetry instance behind a trusted proxy which takes care of mTLS handling, set ```"disable_tls"``` to ```true``` in the config.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -71,5 +71,8 @@ func startServer(config *config.Config, airbrakeNotifier *gobrake.Notifier, logg
 	if server.TLSConfig, err = config.ExtractServiceTLSConfig(logger); err != nil {
 		return err
 	}
+	if config.DisableTLS {
+		return server.ListenAndServe()
+	}
 	return server.ListenAndServeTLS(config.TLS.ServerCert, config.TLS.ServerKey)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,10 @@ type Config struct {
 	// TLS contains certificates & CA info for the webserver
 	TLS *TLS `json:"tls,omitempty"`
 
+	// DisableTLS disables mTLS
+	// Only set to true if there's a reverse proxy in front taking care of mTLS handling
+	DisableTLS bool `json:"disable_tls,omitempty"`
+
 	// UseDefaultEngCA overrides default CA to eng
 	UseDefaultEngCA bool `json:"use_default_eng_ca"`
 
@@ -183,8 +187,12 @@ func (c *Config) AirbrakeTlsConfig() (*tls.Config, error) {
 
 // ExtractServiceTLSConfig return the TLS config needed for stating the mTLS Server
 func (c *Config) ExtractServiceTLSConfig(logger *logrus.Logger) (*tls.Config, error) {
-	if c.TLS == nil {
+	if c.TLS == nil && !c.DisableTLS {
 		return nil, errors.New("tls config is empty - telemetry server is mTLS only, make sure to provide certificates in the config")
+	}
+
+	if c.DisableTLS {
+		return nil, nil
 	}
 
 	var caFileBytes []byte

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -68,6 +68,13 @@ var _ = Describe("Test full application config", func() {
 			Expect(err).To(MatchError("tls config is empty - telemetry server is mTLS only, make sure to provide certificates in the config"))
 		})
 
+		It("does not fail when TLS is nil but DisableTLS is true ", func() {
+			config = &Config{}
+			config.DisableTLS = true
+			_, err := config.ExtractServiceTLSConfig(log)
+			Expect(err).To(BeNil())
+		})
+
 		It("fails when files are missing", func() {
 			_, err := config.ExtractServiceTLSConfig(log)
 			Expect(err).To(MatchError("open tesla.ca: no such file or directory"))
@@ -113,6 +120,12 @@ var _ = Describe("Test full application config", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(config.Port).To(BeEquivalentTo(443))
 			Expect(config.StatusPort).To(BeEquivalentTo(8080))
+		})
+
+		It("not disable TLS", func() {
+			config, err := loadTestApplicationConfig(TestSmallConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.DisableTLS).To(BeFalse())
 		})
 
 		It("transmitrecords disabled by default", func() {

--- a/examples/server_config_disable_mtls.json
+++ b/examples/server_config_disable_mtls.json
@@ -1,0 +1,30 @@
+{
+  "host": "0.0.0.0",
+  "port": 80,
+  "log_level": "info",
+  "json_log_enable": true,
+  "namespace": "tesla_telemetry",
+  "reliable_ack": false,
+  "monitoring": {
+      "prometheus_metrics_port": 9090,
+      "profiler_port": 4269,
+      "profiling_path": "/tmp/trace.out"
+  },
+  "rate_limit": {
+      "enabled": true,
+      "message_interval_time": 30,
+      "message_limit": 1000
+  },
+  "records": {
+      "alerts": [
+          "logger"
+      ],
+      "errors": [
+          "logger"
+      ],
+      "V": [
+          "logger"
+      ]
+  },
+  "disable_tls": true
+}

--- a/server/streaming/server.go
+++ b/server/streaming/server.go
@@ -114,7 +114,7 @@ func serveHTTPWithLogs(h http.Handler, logger *logrus.Logger) http.Handler {
 func (s *Server) Status(config *config.Config) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if config.DisableTLS {
-			fmt.Fprint(w, "mtls disabled")
+			fmt.Fprint(w, "ok")
 		} else {
 			fmt.Fprint(w, "mtls ok")
 		}

--- a/server/streaming/server.go
+++ b/server/streaming/server.go
@@ -72,7 +72,7 @@ func InitServer(c *config.Config, airbrakeHandler *airbrake.AirbrakeHandler, pro
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", socketServer.ServeBinaryWs(c))
-	mux.Handle("/status", socketServer.airbrakeHandler.WithReporting(http.HandlerFunc(socketServer.Status())))
+	mux.Handle("/status", socketServer.airbrakeHandler.WithReporting(http.HandlerFunc(socketServer.Status(c))))
 
 	server := &http.Server{Addr: fmt.Sprintf("%v:%v", c.Host, c.Port), Handler: serveHTTPWithLogs(mux, logger)}
 	go socketServer.handleAcks()
@@ -111,9 +111,13 @@ func serveHTTPWithLogs(h http.Handler, logger *logrus.Logger) http.Handler {
 }
 
 // Status API shows server with mtls config is up
-func (s *Server) Status() func(w http.ResponseWriter, r *http.Request) {
+func (s *Server) Status(config *config.Config) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, "mtls ok")
+		if config.DisableTLS {
+			fmt.Fprint(w, "mtls disabled")
+		} else {
+			fmt.Fprint(w, "mtls ok")
+		}
 	}
 }
 


### PR DESCRIPTION
# Description

This PR adds support for disabling mTLS/TLS. This allows for running fleet telemetry behind a trusted proxy in a secure network which takes care of mTLS handling. mTLS can be disabled in the config by setting ```disable_tls``` to ```true```. By default, this value is not set (= false), resulting in the same behaviour as before and ensuring a secure configuration.

Fixes #171 

## Type of change

Please select all options that apply to this change:

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding updates to the documentation.
- [x] I have added/updated unit tests to cover my changes.
- [x] I have added/updated integration tests to cover my changes.
