### PR TITLE
improve record log formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ For ease of installation and operation, run Fleet Telemetry on Kubernetes or a s
       "flush_period": int - ms flush period
     }
   },
+  "logger": {
+    "verbose": bool - include data types in the logs. Only applicable for records of type 'V'
+  },
   "kafka": { // librdkafka kafka config, seen here: https://raw.githubusercontent.com/confluentinc/librdkafka/master/CONFIGURATION.md
     "bootstrap.servers": "kafka:9092",
     "queue.buffering.max.messages": 1000000

--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,9 @@ type Config struct {
 	// Monitoring defines information for metrics
 	Monitoring *metrics.MonitoringConfig `json:"monitoring,omitempty"`
 
+	// LoggerConfig configures the simple logger
+	LoggerConfig *simple.Config `json:"logger,omitempty"`
+
 	// LogLevel set the log-level
 	LogLevel string `json:"log_level,omitempty"`
 
@@ -250,7 +253,7 @@ func (c *Config) ConfigureProducers(airbrakeHandler *airbrake.AirbrakeHandler, l
 	}
 
 	producers := make(map[telemetry.Dispatcher]telemetry.Producer)
-	producers[telemetry.Logger] = simple.NewProtoLogger(logger)
+	producers[telemetry.Logger] = simple.NewProtoLogger(c.LoggerConfig, logger)
 
 	requiredDispatchers := make(map[telemetry.Dispatcher][]string)
 	for recordName, dispatchRules := range c.Records {

--- a/config/config_initializer.go
+++ b/config/config_initializer.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus/hooks/test"
 
+	"github.com/teslamotors/fleet-telemetry/datastore/simple"
 	logrus "github.com/teslamotors/fleet-telemetry/logger"
 	"github.com/teslamotors/fleet-telemetry/metrics"
 	"github.com/teslamotors/fleet-telemetry/telemetry"
@@ -41,7 +42,9 @@ func loadApplicationConfig(configFilePath string) (*Config, error) {
 		return nil, err
 	}
 
-	config := &Config{}
+	config := &Config{
+		LoggerConfig: &simple.Config{},
+	}
 	err = json.NewDecoder(configFile).Decode(&config)
 	if err != nil {
 		return nil, err

--- a/config/config_initializer_test.go
+++ b/config/config_initializer_test.go
@@ -42,6 +42,7 @@ var _ = Describe("Test application config initialization", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		expectedConfig.MetricCollector = loadedConfig.MetricCollector
+		expectedConfig.LoggerConfig = loadedConfig.LoggerConfig
 		expectedConfig.AckChan = loadedConfig.AckChan
 		Expect(loadedConfig).To(Equal(expectedConfig))
 	})
@@ -67,6 +68,8 @@ var _ = Describe("Test application config initialization", func() {
 		loadedConfig, err := loadTestApplicationConfig(TestSmallConfig)
 		Expect(err).NotTo(HaveOccurred())
 
+		Expect(loadedConfig.LoggerConfig).ToNot(BeNil())
+		expectedConfig.LoggerConfig = loadedConfig.LoggerConfig
 		expectedConfig.MetricCollector = loadedConfig.MetricCollector
 		expectedConfig.AckChan = loadedConfig.AckChan
 		Expect(loadedConfig).To(Equal(expectedConfig))

--- a/datastore/simple/logger.go
+++ b/datastore/simple/logger.go
@@ -1,18 +1,28 @@
 package simple
 
 import (
+	"fmt"
+
+	"github.com/teslamotors/fleet-telemetry/datastore/simple/transformers"
 	logrus "github.com/teslamotors/fleet-telemetry/logger"
+	"github.com/teslamotors/fleet-telemetry/protos"
 	"github.com/teslamotors/fleet-telemetry/telemetry"
 )
 
+type Config struct {
+	// Verbose controls whether types are explicitly shown in the logs. Only applicable for record type 'V'.
+	Verbose bool `json:"verbose"`
+}
+
 // ProtoLogger is a simple protobuf logger
 type ProtoLogger struct {
+	Config *Config
 	logger *logrus.Logger
 }
 
 // NewProtoLogger initializes the parameters for protobuf payload logging
-func NewProtoLogger(logger *logrus.Logger) telemetry.Producer {
-	return &ProtoLogger{logger: logger}
+func NewProtoLogger(config *Config, logger *logrus.Logger) telemetry.Producer {
+	return &ProtoLogger{Config: config, logger: logger}
 }
 
 // SetReliableAckTxType no-op for logger datastore
@@ -21,15 +31,42 @@ func (p *ProtoLogger) ProcessReliableAck(entry *telemetry.Record) {
 
 // Produce sends the data to the logger
 func (p *ProtoLogger) Produce(entry *telemetry.Record) {
-	data, err := entry.GetJSONPayload()
+	data, err := p.recordToLogMap(entry)
 	if err != nil {
 		p.logger.ErrorLog("json_unmarshal_error", err, logrus.LogInfo{"vin": entry.Vin, "metadata": entry.Metadata()})
 		return
 	}
-	p.logger.ActivityLog("logger_json_unmarshal", logrus.LogInfo{"vin": entry.Vin, "metadata": entry.Metadata(), "data": string(data)})
+	p.logger.ActivityLog("logger_json_unmarshal", logrus.LogInfo{"vin": entry.Vin, "metadata": entry.Metadata(), "data": data})
 }
 
 // ReportError noop method
 func (p *ProtoLogger) ReportError(message string, err error, logInfo logrus.LogInfo) {
 	return
+}
+
+// recordToLogMap converts the data of a record to a map or slice of maps
+func (p *ProtoLogger) recordToLogMap(record *telemetry.Record) (interface{}, error) {
+	payload, err := record.GetProtoMessage()
+	if err != nil {
+		return nil, err
+	}
+
+	switch payload := payload.(type) {
+	case *protos.Payload:
+		return transformers.PayloadToMap(payload, p.Config.Verbose, p.logger), nil
+	case *protos.VehicleAlerts:
+		alertMaps := make([]map[string]interface{}, len(payload.Alerts))
+		for i, alert := range payload.Alerts {
+			alertMaps[i] = transformers.VehicleAlertToMap(alert)
+		}
+		return alertMaps, nil
+	case *protos.VehicleErrors:
+		errorMaps := make([]map[string]interface{}, len(payload.Errors))
+		for i, vehicleError := range payload.Errors {
+			errorMaps[i] = transformers.VehicleErrorToMap(vehicleError)
+		}
+		return errorMaps, nil
+	default:
+		return nil, fmt.Errorf("unknown txType: %s", record.TxType)
+	}
 }

--- a/datastore/simple/logger_test.go
+++ b/datastore/simple/logger_test.go
@@ -1,0 +1,137 @@
+package simple_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/teslamotors/fleet-telemetry/datastore/simple"
+	logrus "github.com/teslamotors/fleet-telemetry/logger"
+	"github.com/teslamotors/fleet-telemetry/protos"
+	"github.com/teslamotors/fleet-telemetry/telemetry"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var _ = Describe("ProtoLogger", func() {
+	var (
+		protoLogger *simple.ProtoLogger
+		testLogger  *logrus.Logger
+		hook        *test.Hook
+		config      *simple.Config
+	)
+
+	BeforeEach(func() {
+		testLogger, hook = logrus.NoOpLogger()
+		config = &simple.Config{Verbose: false}
+		protoLogger = simple.NewProtoLogger(config, testLogger).(*simple.ProtoLogger)
+	})
+
+	Describe("NewProtoLogger", func() {
+		It("creates a new ProtoLogger", func() {
+			Expect(protoLogger).NotTo(BeNil())
+			Expect(protoLogger.Config).To(Equal(config))
+		})
+	})
+
+	Describe("ProcessReliableAck", func() {
+		It("does not panic", func() {
+			entry := &telemetry.Record{}
+			Expect(func() { protoLogger.ProcessReliableAck(entry) }).NotTo(Panic())
+		})
+	})
+
+	Describe("Produce", func() {
+		var (
+			record *telemetry.Record
+		)
+
+		BeforeEach(func() {
+			payload := &protos.Payload{
+				Vin:       "TEST123",
+				CreatedAt: timestamppb.New(time.Unix(0, 0)),
+				Data: []*protos.Datum{
+					{
+						Key: protos.Field_VehicleName,
+						Value: &protos.Value{
+							Value: &protos.Value_StringValue{StringValue: "TestVehicle"},
+						},
+					},
+					{
+						Key: protos.Field_Gear,
+						Value: &protos.Value{
+							Value: &protos.Value_ShiftStateValue{ShiftStateValue: protos.ShiftState_ShiftStateD},
+						},
+					},
+				},
+			}
+			payloadBytes, err := proto.Marshal(payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			record = &telemetry.Record{
+				Vin:          "TEST123",
+				PayloadBytes: payloadBytes,
+				TxType:       "V",
+			}
+		})
+
+		It("logs data", func() {
+			protoLogger.Produce(record)
+
+			lastLog := hook.LastEntry()
+			Expect(lastLog.Message).To(Equal("logger_json_unmarshal"))
+			Expect(lastLog.Data).To(HaveKeyWithValue("vin", "TEST123"))
+			Expect(lastLog.Data).To(HaveKey("data"))
+
+			data, ok := lastLog.Data["data"].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(data).To(Equal(map[string]interface{}{
+				"VehicleName": "TestVehicle",
+				"Gear":        "ShiftStateD",
+				"Vin":         "TEST123",
+				"CreatedAt":   "1970-01-01T00:00:00Z",
+			}))
+		})
+
+		It("logs an error when unmarshaling fails", func() {
+			record.PayloadBytes = []byte("invalid payload")
+			protoLogger.Produce(record)
+
+			lastLog := hook.LastEntry()
+			Expect(lastLog.Message).To(Equal("json_unmarshal_error"))
+			Expect(lastLog.Data).To(HaveKeyWithValue("vin", "TEST123"))
+			Expect(lastLog.Data).To(HaveKey("metadata"))
+		})
+
+		Context("when verbose set to true", func() {
+			BeforeEach(func() {
+				config.Verbose = true
+				protoLogger = simple.NewProtoLogger(config, testLogger).(*simple.ProtoLogger)
+			})
+
+			It("does not include types in the data", func() {
+				protoLogger.Produce(record)
+
+				data, ok := hook.LastEntry().Data["data"].(map[string]interface{})
+				Expect(ok).To(BeTrue())
+				Expect(data).To(Equal(map[string]interface{}{
+					"VehicleName": map[string]interface{}{"stringValue": "TestVehicle"},
+					"Gear":        map[string]interface{}{"shiftStateValue": "ShiftStateD"},
+					"Vin":         "TEST123",
+					"CreatedAt":   "1970-01-01T00:00:00Z",
+				}))
+			})
+		})
+	})
+
+	Describe("ReportError", func() {
+		It("succeeds", func() {
+			Expect(func() {
+				protoLogger.ReportError("test error", nil, logrus.LogInfo{})
+			}).NotTo(Panic())
+		})
+	})
+})

--- a/datastore/simple/simple_suite_test.go
+++ b/datastore/simple/simple_suite_test.go
@@ -1,0 +1,13 @@
+package simple_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSimple(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Simple Suite Tests")
+}

--- a/datastore/simple/transformers/payload.go
+++ b/datastore/simple/transformers/payload.go
@@ -1,0 +1,83 @@
+package transformers
+
+import (
+	"time"
+
+	logrus "github.com/teslamotors/fleet-telemetry/logger"
+	"github.com/teslamotors/fleet-telemetry/protos"
+)
+
+func PayloadToMap(payload *protos.Payload, includeTypes bool, logger *logrus.Logger) map[string]interface{} {
+	convertedPayload := make(map[string]interface{}, len(payload.Data)+2)
+	convertedPayload["Vin"] = payload.Vin
+	convertedPayload["CreatedAt"] = payload.CreatedAt.AsTime().Format(time.RFC3339)
+
+	for _, datum := range payload.Data {
+		if datum == nil || datum.Value == nil {
+			logger.ActivityLog("unknown_payload_data_type", logrus.LogInfo{"vin": payload.Vin})
+			continue
+		}
+		name := protos.Field_name[int32(datum.Key.Number())]
+		value, ok := transformValue(datum.Value.Value, includeTypes)
+		if !ok {
+			logger.ActivityLog("unknown_payload_value_data_type", logrus.LogInfo{"name": name, "vin": payload.Vin})
+			continue
+		}
+		convertedPayload[name] = value
+	}
+
+	return convertedPayload
+}
+
+func transformValue(value interface{}, includeTypes bool) (interface{}, bool) {
+	var outputValue interface{}
+	var outputType string
+
+	// ordered by expected frequency
+	switch v := value.(type) {
+	case *protos.Value_StringValue:
+		outputType = "stringValue"
+		outputValue = v.StringValue
+	case *protos.Value_LocationValue:
+		outputType = "locationValue"
+		outputValue = map[string]float64{
+			"latitude":  v.LocationValue.Latitude,
+			"longitude": v.LocationValue.Longitude,
+		}
+	case *protos.Value_FloatValue:
+		outputType = "floatValue"
+		outputValue = v.FloatValue
+	case *protos.Value_IntValue:
+		outputType = "intValue"
+		outputValue = v.IntValue
+	case *protos.Value_DoubleValue:
+		outputType = "doubleValue"
+		outputValue = v.DoubleValue
+	case *protos.Value_LongValue:
+		outputType = "longValue"
+		outputValue = v.LongValue
+	case *protos.Value_BooleanValue:
+		outputType = "booleanValue"
+		outputValue = v.BooleanValue
+	case *protos.Value_Invalid:
+		outputType = "invalid"
+		outputValue = "<invalid>"
+		if includeTypes {
+			outputValue = true
+		}
+	case *protos.Value_ShiftStateValue:
+		outputType = "shiftStateValue"
+		outputValue = v.ShiftStateValue.String()
+	case *protos.Value_ChargingValue:
+		outputType = "chargingValue"
+		outputValue = v.ChargingValue.String()
+	default:
+		return nil, false
+	}
+
+	if includeTypes {
+		return map[string]interface{}{outputType: outputValue}, true
+	}
+
+	return outputValue, true
+}

--- a/datastore/simple/transformers/payload_test.go
+++ b/datastore/simple/transformers/payload_test.go
@@ -1,0 +1,196 @@
+package transformers_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/teslamotors/fleet-telemetry/datastore/simple/transformers"
+	logrus "github.com/teslamotors/fleet-telemetry/logger"
+	"github.com/teslamotors/fleet-telemetry/protos"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var _ = Describe("Payload", func() {
+	logger, _ := logrus.NoOpLogger()
+	Describe("PayloadToMap", func() {
+		It("includes the vin and createdAt fields", func() {
+			now := timestamppb.Now()
+			payload := &protos.Payload{
+				Data:      []*protos.Datum{},
+				Vin:       "TEST123",
+				CreatedAt: now,
+			}
+			result := transformers.PayloadToMap(payload, false, logger)
+			Expect(result["Vin"]).To(Equal("TEST123"))
+			Expect(result["CreatedAt"]).To(Equal(now.AsTime().Format(time.RFC3339)))
+		})
+
+		It("handles nil data", func() {
+			now := timestamppb.Now()
+			payload := &protos.Payload{
+				Data: []*protos.Datum{
+					nil,
+					&protos.Datum{
+						Value: nil,
+					},
+					&protos.Datum{
+						Key: protos.Field_BatteryHeaterOn,
+						Value: &protos.Value{
+							Value: &protos.Value_BooleanValue{BooleanValue: true},
+						},
+					},
+				},
+				Vin:       "TEST123",
+				CreatedAt: now,
+			}
+			result := transformers.PayloadToMap(payload, false, logger)
+			Expect(result["Vin"]).To(Equal("TEST123"))
+			Expect(result["CreatedAt"]).To(Equal(now.AsTime().Format(time.RFC3339)))
+			Expect(result["BatteryHeaterOn"]).To(Equal(true))
+		})
+
+		DescribeTable("converting datum to key-value pairs",
+			func(datum *protos.Datum, includeTypes bool, expectedKey string, expectedValue interface{}) {
+				payload := &protos.Payload{
+					Data:      []*protos.Datum{datum},
+					Vin:       "TEST123",
+					CreatedAt: timestamppb.Now(),
+				}
+				result := transformers.PayloadToMap(payload, includeTypes, logger)
+				Expect(result[expectedKey]).To(Equal(expectedValue))
+			},
+			Entry("String value with types excluded",
+				&protos.Datum{
+					Key:   protos.Field_VehicleName,
+					Value: &protos.Value{Value: &protos.Value_StringValue{StringValue: "CyberBeast"}},
+				},
+				excludeTypes,
+				"VehicleName",
+				"CyberBeast",
+			),
+			Entry("String value with types included",
+				&protos.Datum{
+					Key:   protos.Field_VehicleName,
+					Value: &protos.Value{Value: &protos.Value_StringValue{StringValue: "CyberBeast"}},
+				},
+				includeTypes,
+				"VehicleName",
+				map[string]interface{}{
+					"stringValue": "CyberBeast",
+				},
+			),
+			Entry("Integer value with types excluded",
+				&protos.Datum{
+					Key:   protos.Field_Odometer,
+					Value: &protos.Value{Value: &protos.Value_IntValue{IntValue: 50000}},
+				},
+				excludeTypes,
+				"Odometer",
+				int32(50000),
+			),
+			Entry("Integer value with types included",
+				&protos.Datum{
+					Key:   protos.Field_Odometer,
+					Value: &protos.Value{Value: &protos.Value_IntValue{IntValue: 50000}},
+				},
+				includeTypes,
+				"Odometer",
+				map[string]interface{}{
+					"intValue": int32(50000),
+				},
+			),
+			Entry("Float value with types excluded",
+				&protos.Datum{
+					Key:   protos.Field_BatteryLevel,
+					Value: &protos.Value{Value: &protos.Value_FloatValue{FloatValue: 75.5}},
+				},
+				excludeTypes,
+				"BatteryLevel",
+				float32(75.5),
+			),
+			Entry("Float value with types included",
+				&protos.Datum{
+					Key:   protos.Field_BatteryLevel,
+					Value: &protos.Value{Value: &protos.Value_FloatValue{FloatValue: 75.5}},
+				},
+				includeTypes,
+				"BatteryLevel",
+				map[string]interface{}{
+					"floatValue": float32(75.5),
+				},
+			),
+			Entry("Boolean value with types excluded",
+				&protos.Datum{
+					Key:   protos.Field_SentryMode,
+					Value: &protos.Value{Value: &protos.Value_BooleanValue{BooleanValue: true}},
+				},
+				excludeTypes,
+				"SentryMode",
+				true,
+			),
+			Entry("Boolean value with types included",
+				&protos.Datum{
+					Key:   protos.Field_SentryMode,
+					Value: &protos.Value{Value: &protos.Value_BooleanValue{BooleanValue: true}},
+				},
+				includeTypes,
+				"SentryMode",
+				map[string]interface{}{
+					"booleanValue": true,
+				},
+			),
+			Entry("ShiftState with enums as strings and types excluded",
+				&protos.Datum{
+					Key:   protos.Field_Gear,
+					Value: &protos.Value{Value: &protos.Value_ShiftStateValue{ShiftStateValue: protos.ShiftState_ShiftStateD}},
+				},
+				excludeTypes,
+				"Gear",
+				"ShiftStateD",
+			),
+			Entry("ShiftState with types included",
+				&protos.Datum{
+					Key:   protos.Field_Gear,
+					Value: &protos.Value{Value: &protos.Value_ShiftStateValue{ShiftStateValue: protos.ShiftState_ShiftStateD}},
+				},
+				includeTypes,
+				"Gear",
+				map[string]interface{}{
+					"shiftStateValue": "ShiftStateD",
+				},
+			),
+			Entry("ChargeState with types excluded",
+				&protos.Datum{
+					Key:   protos.Field_ChargeState,
+					Value: &protos.Value{Value: &protos.Value_ChargingValue{ChargingValue: protos.ChargingState_ChargeStateCharging}},
+				},
+				excludeTypes,
+				"ChargeState",
+				"ChargeStateCharging",
+			),
+			Entry("Invalid with types excluded",
+				&protos.Datum{
+					Key:   protos.Field_BMSState,
+					Value: &protos.Value{Value: &protos.Value_Invalid{}},
+				},
+				excludeTypes,
+				"BMSState",
+				"<invalid>",
+			),
+			Entry("Invalid with types included",
+				&protos.Datum{
+					Key:   protos.Field_BMSState,
+					Value: &protos.Value{Value: &protos.Value_Invalid{}},
+				},
+				includeTypes,
+				"BMSState",
+				map[string]interface{}{
+					"invalid": true,
+				},
+			),
+		)
+	})
+})

--- a/datastore/simple/transformers/transformers_suite_test.go
+++ b/datastore/simple/transformers/transformers_suite_test.go
@@ -1,0 +1,13 @@
+package transformers_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTransformers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Transformers Suite Tests")
+}

--- a/datastore/simple/transformers/utilities_test.go
+++ b/datastore/simple/transformers/utilities_test.go
@@ -1,0 +1,8 @@
+package transformers_test
+
+// Utility constants to make tests more readable
+
+const (
+	includeTypes = true
+	excludeTypes = false
+)

--- a/datastore/simple/transformers/vehicle_alert.go
+++ b/datastore/simple/transformers/vehicle_alert.go
@@ -1,0 +1,33 @@
+package transformers
+
+import (
+	"github.com/teslamotors/fleet-telemetry/protos"
+)
+
+// VehicleAlertToMap converts a VehicleAlert proto message to a map representation
+func VehicleAlertToMap(alert *protos.VehicleAlert) map[string]interface{} {
+	alertMap := map[string]interface{}{
+		"Name": alert.Name,
+	}
+
+	if alert.StartedAt != nil {
+		alertMap["StartedAt"] = alert.StartedAt.AsTime().Unix()
+	}
+
+	if alert.EndedAt != nil {
+		alertMap["EndedAt"] = alert.EndedAt.AsTime().Unix()
+	}
+
+	if alert.Audiences == nil {
+		alertMap["Audiences"] = nil
+		return alertMap
+	}
+
+	audiences := make([]interface{}, len(alert.Audiences))
+	for i, audience := range alert.Audiences {
+		audiences[i] = audience.String()
+	}
+	alertMap["Audiences"] = audiences
+
+	return alertMap
+}

--- a/datastore/simple/transformers/vehicle_alert_test.go
+++ b/datastore/simple/transformers/vehicle_alert_test.go
@@ -1,0 +1,52 @@
+package transformers_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/teslamotors/fleet-telemetry/datastore/simple/transformers"
+	"github.com/teslamotors/fleet-telemetry/protos"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var _ = Describe("VehicleAlert", func() {
+	Describe("VehicleAlertToMap", func() {
+		var (
+			alert *protos.VehicleAlert
+		)
+
+		BeforeEach(func() {
+			alert = &protos.VehicleAlert{
+				Name:      "TestAlert",
+				StartedAt: timestamppb.New(time.Now().Add(-1 * time.Hour)),
+				EndedAt:   timestamppb.New(time.Now()),
+				Audiences: []protos.Audience{protos.Audience_Customer, protos.Audience_Service},
+			}
+		})
+
+		It("includes all expected data", func() {
+			result := transformers.VehicleAlertToMap(alert)
+
+			Expect(result).To(HaveLen(4))
+			Expect(result["Name"]).To(Equal("TestAlert"))
+			Expect(result["StartedAt"]).To(BeNumerically("~", time.Now().Add(-1*time.Hour).Unix(), 1))
+			Expect(result["EndedAt"]).To(BeNumerically("~", time.Now().Unix(), 1))
+			Expect(result["Audiences"]).To(ConsistOf("Customer", "Service"))
+		})
+
+		It("handles missing fields", func() {
+			alert.EndedAt = nil
+			alert.Audiences = nil
+			result := transformers.VehicleAlertToMap(alert)
+
+			Expect(result).To(HaveLen(3))
+			Expect(result["Name"]).To(Equal("TestAlert"))
+			Expect(result["StartedAt"]).To(BeNumerically("~", time.Now().Add(-1*time.Hour).Unix(), 1))
+			Expect(result).NotTo(HaveKey("EndedAt"))
+			Expect(result["Audiences"]).To(BeNil())
+		})
+	})
+})

--- a/datastore/simple/transformers/vehicle_error.go
+++ b/datastore/simple/transformers/vehicle_error.go
@@ -1,0 +1,20 @@
+package transformers
+
+import (
+	"github.com/teslamotors/fleet-telemetry/protos"
+)
+
+// VehicleErrorToMap converts a VehicleError proto message to a map representation
+func VehicleErrorToMap(vehicleError *protos.VehicleError) map[string]interface{} {
+	errorMap := map[string]interface{}{
+		"Name": vehicleError.Name,
+		"Body": vehicleError.Body,
+		"Tags": vehicleError.Tags,
+	}
+
+	if vehicleError.CreatedAt != nil {
+		errorMap["CreatedAt"] = vehicleError.CreatedAt.AsTime().Unix()
+	}
+
+	return errorMap
+}

--- a/datastore/simple/transformers/vehicle_error_test.go
+++ b/datastore/simple/transformers/vehicle_error_test.go
@@ -1,0 +1,54 @@
+package transformers_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/teslamotors/fleet-telemetry/datastore/simple/transformers"
+	"github.com/teslamotors/fleet-telemetry/protos"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var _ = Describe("VehicleError", func() {
+	Describe("VehicleErrorToMap", func() {
+		var (
+			vehicleError *protos.VehicleError
+		)
+
+		BeforeEach(func() {
+			vehicleError = &protos.VehicleError{
+				Name:      "TestError",
+				CreatedAt: timestamppb.New(time.Now()),
+				Tags:      map[string]string{"tag1": "value1", "tag2": "value2"},
+				Body:      "Error details",
+			}
+		})
+
+		It("includes all expected data", func() {
+			result := transformers.VehicleErrorToMap(vehicleError)
+
+			Expect(result).To(HaveLen(4))
+			Expect(result["Name"]).To(Equal("TestError"))
+			Expect(result["CreatedAt"]).To(BeNumerically("~", time.Now().Unix(), 1))
+			Expect(result["Tags"]).To(HaveKeyWithValue("tag1", "value1"))
+			Expect(result["Tags"]).To(HaveKeyWithValue("tag2", "value2"))
+			Expect(result["Body"]).To(Equal("Error details"))
+		})
+
+		It("handles missing fields", func() {
+			vehicleError.Tags = nil
+			vehicleError.Body = ""
+
+			result := transformers.VehicleErrorToMap(vehicleError)
+
+			Expect(result).To(HaveLen(4))
+			Expect(result["Name"]).To(Equal("TestError"))
+			Expect(result["CreatedAt"]).To(BeNumerically("~", time.Now().Unix(), 1))
+			Expect(result["Body"]).To(Equal(""))
+			Expect(result["Tags"]).To(BeEmpty())
+		})
+	})
+})

--- a/telemetry/record.go
+++ b/telemetry/record.go
@@ -7,6 +7,7 @@ import (
 
 	logrus "github.com/teslamotors/fleet-telemetry/logger"
 	"github.com/teslamotors/fleet-telemetry/protos"
+
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"

--- a/telemetry/record_test.go
+++ b/telemetry/record_test.go
@@ -346,6 +346,83 @@ func locationDatum(field protos.Field, location *protos.LocationValue) *protos.D
 	}
 }
 
+func intDatum(field protos.Field, value int32) *protos.Datum {
+	return &protos.Datum{
+		Key: field,
+		Value: &protos.Value{
+			Value: &protos.Value_IntValue{
+				IntValue: value,
+			},
+		},
+	}
+}
+
+func doubleDatum(field protos.Field, value float64) *protos.Datum {
+	return &protos.Datum{
+		Key: field,
+		Value: &protos.Value{
+			Value: &protos.Value_DoubleValue{
+				DoubleValue: value,
+			},
+		},
+	}
+}
+
+func boolDatum(field protos.Field, value bool) *protos.Datum {
+	return &protos.Datum{
+		Key: field,
+		Value: &protos.Value{
+			Value: &protos.Value_BooleanValue{
+				BooleanValue: value,
+			},
+		},
+	}
+}
+
+func floatDatum(field protos.Field, value float32) *protos.Datum {
+	return &protos.Datum{
+		Key: field,
+		Value: &protos.Value{
+			Value: &protos.Value_FloatValue{
+				FloatValue: value,
+			},
+		},
+	}
+}
+
+func longDatum(field protos.Field, value int64) *protos.Datum {
+	return &protos.Datum{
+		Key: field,
+		Value: &protos.Value{
+			Value: &protos.Value_LongValue{
+				LongValue: value,
+			},
+		},
+	}
+}
+
+func chargingStateDatum(field protos.Field, value protos.ChargingState) *protos.Datum {
+	return &protos.Datum{
+		Key: field,
+		Value: &protos.Value{
+			Value: &protos.Value_ChargingValue{
+				ChargingValue: value,
+			},
+		},
+	}
+}
+
+func shiftStateDatum(field protos.Field, value protos.ShiftState) *protos.Datum {
+	return &protos.Datum{
+		Key: field,
+		Value: &protos.Value{
+			Value: &protos.Value_ShiftStateValue{
+				ShiftStateValue: value,
+			},
+		},
+	}
+}
+
 // clone creates a "clean" clone of the given proto.LocationValue so we can use DeepEqual freely.
 func clone(o *protos.LocationValue) *protos.LocationValue {
 	if o == nil {


### PR DESCRIPTION
# Description

When using the simple `logger` backend, logs are written to stdout. The `data` field is currently a string with the JSON representation of the received data. This converts the received data into proper types before logging, meaning the log line is all JSON.

Example log output before this change:
```json
{"data":"{\"data\":[{\"key\":\"Soc\", \"value\":{\"stringValue\":\"61.214\"}}], \"createdAt\":\"2024-08-25T00:54:18.761807867Z\", \"vin\":\"VIN\"}"}
```

And after:
```json
{"data":{"Soc":{"stringValue":"61.214"},"Vin":"VIN","CreatedAt":"2024-08-25T00:54:18.761807867Z"}}
```

---

A new option is introduced for `logger`:

 `compact` allows for removing types from the output. Given the example above, the compact form is:
```json
{"data":{"Soc":"61.214","Vin":"VIN","CreatedAt":"2024-08-25T00:54:18.761807867Z"}}
```

## Type of change

Please select all options that apply to this change:

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

This is somewhat of a breaking change since the log format will change. To my knowledge, the `logger` is generally used for debugging. Is this change a concern for anyone?

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding updates to the documentation.
- [x] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
