### PR TITLE
Support docker publish with latest tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,4 +50,4 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: tesla/fleet-telemetry:${{ steps.release.outputs.version }}
+          tags: tesla/fleet-telemetry:latest,tesla/fleet-telemetry:${{ steps.release.outputs.version }}


### PR DESCRIPTION
# Description

We already support publishing latest in vehicle-command https://github.com/teslamotors/vehicle-command/blob/main/.github/workflows/publish.yml#L49. Makes sense to support it here as well

## Type of change

Please select all options that apply to this change:

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
