### PR TITLE
use non root image for fleet telemetry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV CGO_LDFLAGS="-lstdc++"
 RUN make
 
 # hadolint ignore=DL3006
-FROM gcr.io/distroless/cc-debian11
+FROM gcr.io/distroless/cc-debian11:nonroot
 WORKDIR /
 COPY --from=build /go/bin/fleet-telemetry /
 


### PR DESCRIPTION
# Description

Don't think we need root privileges to run fleet telemetry

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
