### PR TITLE
Handle logger when transmit_decoded_records is set to true

### DIFF
--- a/datastore/simple/logger.go
+++ b/datastore/simple/logger.go
@@ -33,7 +33,7 @@ func (p *ProtoLogger) ProcessReliableAck(entry *telemetry.Record) {
 func (p *ProtoLogger) Produce(entry *telemetry.Record) {
 	data, err := p.recordToLogMap(entry)
 	if err != nil {
-		p.logger.ErrorLog("record_logging_error", err, logrus.LogInfo{"vin": entry.Vin, "metadata": entry.Metadata()})
+		p.logger.ErrorLog("record_logging_error", err, logrus.LogInfo{"vin": entry.Vin, "txtype": entry.TxType, "metadata": entry.Metadata()})
 		return
 	}
 	p.logger.ActivityLog("record_payload", logrus.LogInfo{"vin": entry.Vin, "metadata": entry.Metadata(), "data": data})
@@ -45,12 +45,7 @@ func (p *ProtoLogger) ReportError(message string, err error, logInfo logrus.LogI
 
 // recordToLogMap converts the data of a record to a map or slice of maps
 func (p *ProtoLogger) recordToLogMap(record *telemetry.Record) (interface{}, error) {
-	payload, err := record.GetProtoMessage()
-	if err != nil {
-		return nil, err
-	}
-
-	switch payload := payload.(type) {
+	switch payload := record.GetProtoMessage().(type) {
 	case *protos.Payload:
 		return transformers.PayloadToMap(payload, p.Config.Verbose, p.logger), nil
 	case *protos.VehicleAlerts:

--- a/datastore/simple/logger_test.go
+++ b/datastore/simple/logger_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/teslamotors/fleet-telemetry/datastore/simple"
 	logrus "github.com/teslamotors/fleet-telemetry/logger"
+	"github.com/teslamotors/fleet-telemetry/messages"
 	"github.com/teslamotors/fleet-telemetry/protos"
 	"github.com/teslamotors/fleet-telemetry/telemetry"
 
@@ -46,7 +47,8 @@ var _ = Describe("ProtoLogger", func() {
 
 	Describe("Produce", func() {
 		var (
-			record *telemetry.Record
+			streamMessageBytes []byte
+			serializer         *telemetry.BinarySerializer
 		)
 
 		BeforeEach(func() {
@@ -71,40 +73,45 @@ var _ = Describe("ProtoLogger", func() {
 			payloadBytes, err := proto.Marshal(payload)
 			Expect(err).NotTo(HaveOccurred())
 
-			record = &telemetry.Record{
-				Vin:          "TEST123",
-				PayloadBytes: payloadBytes,
-				TxType:       "V",
-			}
+			logger, _ := logrus.NoOpLogger()
+			serializer = telemetry.NewBinarySerializer(
+				&telemetry.RequestIdentity{
+					DeviceID: "TEST123",
+					SenderID: "vehicle_device.TEST123",
+				},
+				map[string][]telemetry.Producer{},
+				logger,
+			)
+			message := messages.StreamMessage{TXID: []byte("1234"), SenderID: []byte("vehicle_device.TEST123"), MessageTopic: []byte("V"), Payload: payloadBytes}
+			streamMessageBytes, err = message.ToBytes()
+			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("logs data", func() {
-			protoLogger.Produce(record)
+		DescribeTable("logs data",
+			func(useDecoded bool) {
+				record, err := telemetry.NewRecord(serializer, streamMessageBytes, "1", useDecoded)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(record).NotTo(BeNil())
 
-			lastLog := hook.LastEntry()
-			Expect(lastLog.Message).To(Equal("record_payload"))
-			Expect(lastLog.Data).To(HaveKeyWithValue("vin", "TEST123"))
-			Expect(lastLog.Data).To(HaveKey("data"))
+				protoLogger.Produce(record)
 
-			data, ok := lastLog.Data["data"].(map[string]interface{})
-			Expect(ok).To(BeTrue())
-			Expect(data).To(Equal(map[string]interface{}{
-				"VehicleName": "TestVehicle",
-				"Gear":        "ShiftStateD",
-				"Vin":         "TEST123",
-				"CreatedAt":   "1970-01-01T00:00:00Z",
-			}))
-		})
+				lastLog := hook.LastEntry()
+				Expect(lastLog.Message).To(Equal("record_payload"))
+				Expect(lastLog.Data).To(HaveKeyWithValue("vin", "TEST123"))
+				Expect(lastLog.Data).To(HaveKey("data"))
 
-		It("logs an error when unmarshaling fails", func() {
-			record.PayloadBytes = []byte("invalid payload")
-			protoLogger.Produce(record)
-
-			lastLog := hook.LastEntry()
-			Expect(lastLog.Message).To(Equal("record_logging_error"))
-			Expect(lastLog.Data).To(HaveKeyWithValue("vin", "TEST123"))
-			Expect(lastLog.Data).To(HaveKey("metadata"))
-		})
+				data, ok := lastLog.Data["data"].(map[string]interface{})
+				Expect(ok).To(BeTrue())
+				Expect(data).To(Equal(map[string]interface{}{
+					"VehicleName": "TestVehicle",
+					"Gear":        "ShiftStateD",
+					"Vin":         "TEST123",
+					"CreatedAt":   "1970-01-01T00:00:00Z",
+				}))
+			},
+			Entry("record", true),
+			Entry("decoded record", false),
+		)
 
 		Context("when verbose set to true", func() {
 			BeforeEach(func() {
@@ -113,6 +120,10 @@ var _ = Describe("ProtoLogger", func() {
 			})
 
 			It("does not include types in the data", func() {
+				record, err := telemetry.NewRecord(serializer, streamMessageBytes, "1", true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(record).NotTo(BeNil())
+
 				protoLogger.Produce(record)
 
 				data, ok := hook.LastEntry().Data["data"].(map[string]interface{})

--- a/telemetry/record_test.go
+++ b/telemetry/record_test.go
@@ -2,6 +2,7 @@ package telemetry_test
 
 import (
 	"crypto/rand"
+	"fmt"
 	"sort"
 	"time"
 
@@ -258,32 +259,50 @@ var _ = Describe("Socket handler test", func() {
 
 	Describe("GetProtoMessage", func() {
 		DescribeTable("valid alert types",
-			func(txType string, input proto.Message, verifyOutput func(proto.Message) bool) {
+			func(txType string, vin string, input proto.Message, verifyOutput func(proto.Message) bool) {
 				payloadBytes, err := proto.Marshal(input)
 				Expect(err).NotTo(HaveOccurred())
-				record := &telemetry.Record{
-					TxType:       txType,
-					PayloadBytes: payloadBytes,
-				}
-				output, err := record.GetProtoMessage()
+
+				message := messages.StreamMessage{TXID: []byte("1234"), DeviceID: []byte(vin), SenderID: []byte(fmt.Sprintf("vehicle_device.%s", vin)), MessageTopic: []byte(txType), Payload: payloadBytes}
+				recordMsg, err := message.ToBytes()
 				Expect(err).NotTo(HaveOccurred())
+
+				serializer = telemetry.NewBinarySerializer(
+					&telemetry.RequestIdentity{
+						DeviceID: vin,
+						SenderID: fmt.Sprintf("vehicle_device.%s", vin),
+					},
+					map[string][]telemetry.Producer{"D4": nil},
+					logger,
+				)
+
+				record, err := telemetry.NewRecord(serializer, recordMsg, "1", true)
+				Expect(err).NotTo(HaveOccurred())
+				output := record.GetProtoMessage()
 				Expect(verifyOutput(output)).To(BeTrue())
 			},
-			Entry("for txType alerts", "alerts", &protos.VehicleAlerts{Vin: "testAlertVin"}, func(msg proto.Message) bool {
+			Entry("for txType alerts", "alerts", "testAlertVin", &protos.VehicleAlerts{Vin: "testAlertVin"}, func(msg proto.Message) bool {
 				myMsg, ok := msg.(*protos.VehicleAlerts)
 				if !ok {
 					return false
 				}
 				return myMsg.GetVin() == "testAlertVin"
 			}),
-			Entry("for txType errors", "errors", &protos.VehicleErrors{Vin: "testErrorVin"}, func(msg proto.Message) bool {
+			Entry("for txType errors", "errors", "testErrorVin", &protos.VehicleErrors{Vin: "testErrorVin"}, func(msg proto.Message) bool {
 				myMsg, ok := msg.(*protos.VehicleErrors)
 				if !ok {
 					return false
 				}
 				return myMsg.GetVin() == "testErrorVin"
 			}),
-			Entry("for txType V", "V", &protos.Payload{Vin: "testPayloadVIN"}, func(msg proto.Message) bool {
+			Entry("for txType connectivity", "connectivity", "testConnectivityVin", &protos.VehicleConnectivity{Vin: "testConnectivityVin"}, func(msg proto.Message) bool {
+				myMsg, ok := msg.(*protos.VehicleConnectivity)
+				if !ok {
+					return false
+				}
+				return myMsg.GetVin() == "testConnectivityVin"
+			}),
+			Entry("for txType V", "V", "testPayloadVIN", &protos.Payload{Vin: "testPayloadVIN"}, func(msg proto.Message) bool {
 				myMsg, ok := msg.(*protos.Payload)
 				if !ok {
 					return false
@@ -291,14 +310,6 @@ var _ = Describe("Socket handler test", func() {
 				return myMsg.GetVin() == "testPayloadVIN"
 			}),
 		)
-
-		It("errors on unknown txtype", func() {
-			record := &telemetry.Record{
-				TxType: "badTxType",
-			}
-			_, err := record.GetProtoMessage()
-			Expect(err).To(MatchError("no mapping for txType: badTxType"))
-		})
 
 		It("json payload returns valid data when transmitDecodedRecords is false", func() {
 			message := messages.StreamMessage{TXID: []byte("1234"), SenderID: []byte("vehicle_device.42"), MessageTopic: []byte("V"), Payload: generatePayload("cybertruck", "42", nil)}
@@ -332,16 +343,6 @@ var _ = Describe("Socket handler test", func() {
 			data, err := record.GetJSONPayload()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(record.Payload()).To(Equal(data))
-		})
-
-		It("returns error on invalid txType", func() {
-			message := messages.StreamMessage{TXID: []byte("1234"), SenderID: []byte("vehicle_device.42"), MessageTopic: []byte("INVALID"), Payload: generatePayload("cybertruck", "42", nil)}
-			recordMsg, err := message.ToBytes()
-			Expect(err).NotTo(HaveOccurred())
-
-			record, err := telemetry.NewRecord(serializer, recordMsg, "1", true)
-			Expect(err).To(MatchError("no mapping for txType: INVALID"))
-			Expect(record).NotTo(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
# Description

- It seems record logger is broken when `transmit_decoded_records` is set to true. 
- Most likely logger broke when when https://github.com/teslamotors/fleet-telemetry/pull/200 started using `GetProtoMessage` to get protobuf message for custom logging. The reason the current implementation is wrong is because `GetProtoMessage` operation wasn't idempotent. 
- This PR stores the proto message during record creation itself
- Added tests

Fixes  https://github.com/teslamotors/fleet-telemetry/issues/230

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [X] My code follows the style of this project.
- [X] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [X] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
