### PR TITLE
cache pubsub topic and reuse it to publish future messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ Dispatchers handle vehicle data processing upon its arrival at Fleet Telemetry s
   * Configure stream names directly by setting the streams config `"kinesis": { "streams": { *topic_name*: stream_name } }`
   * Override stream names with env variables: KINESIS_STREAM_\*uppercase topic\* ex.: `KINESIS_STREAM_V`
 * Google pubsub: Along with the required pubsub config (See ./test/integration/config.json for example), be sure to set the environment variable `GOOGLE_APPLICATION_CREDENTIALS`
+  * If you have already created relevant topics, you can use `topic_check_refresh_interval_seconds` to update server's behavior:-
+    * 0 (default) : Will always attempt to create and check existence of topic before publishing
+    * -1 : Will attempt to dispatch the message without checking the existence of topic. Set this to -1, if topics were created before deploying
+    * x : Will only attempt to check existence of topic every x seconds. If the topic was deleted, it will attempt to recreate after x seconds. 
 * ZMQ: Configure with the config.json file.  See implementation here: [config/config.go](./config/config.go)
 * Logger: This is a simple STDOUT logger that serializes the protos to json.
 

--- a/config/config.go
+++ b/config/config.go
@@ -131,6 +131,9 @@ type Pubsub struct {
 	// GCP Project ID
 	ProjectID string `json:"gcp_project_id,omitempty"`
 
+	// TopicCheckRefreshIntervalSeconds -1: do not check if topic exists, 0: always check, non zero value signifies refresh interval for check
+	TopicCheckRefreshIntervalSeconds int `json:"topic_check_refresh_interval_seconds,omitempty"`
+
 	Publisher *pubsub.Client
 }
 
@@ -281,7 +284,7 @@ func (c *Config) ConfigureProducers(airbrakeHandler *airbrake.Handler, logger *l
 		if c.Pubsub == nil {
 			return nil, nil, errors.New("expected Pubsub to be configured")
 		}
-		googleProducer, err := googlepubsub.NewProducer(c.prometheusEnabled(), c.Pubsub.ProjectID, c.Namespace, c.MetricCollector, airbrakeHandler, c.AckChan, reliableAckSources[telemetry.Pubsub], logger)
+		googleProducer, err := googlepubsub.NewProducer(c.prometheusEnabled(), c.Pubsub.ProjectID, c.Namespace, c.Pubsub.TopicCheckRefreshIntervalSeconds, c.MetricCollector, airbrakeHandler, c.AckChan, reliableAckSources[telemetry.Pubsub], logger)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
# Description

- to prevent hitting resource quota, cache the google pubsub topic and reuse it for future data transmissions

Fixes # (https://github.com/teslamotors/fleet-telemetry/issues/289)

## Type of change

Please select all options that apply to this change:

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [X] My code follows the style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
