### PR TITLE
fix publishing of docker images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   validate-input:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Validate input
         id: validate
@@ -22,7 +22,7 @@ jobs:
 
   release:
     needs: validate-input
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,19 +34,19 @@ jobs:
           tag_prefix: v
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v4
         with:
           platforms: linux/amd64,linux/arm64
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start by building the application.
-FROM golang:1.23.0-bullseye as build
+FROM golang:1.23.0-bullseye AS build
 
 # build libsodium (dep of libzmq)
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Start by building the application.
-FROM golang:1.23.0-bullseye AS build
+FROM golang:1.23.0-bullseye as build
 
 # build libsodium (dep of libzmq)
 WORKDIR /build
-RUN wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.19.tar.gz
+RUN wget https://github.com/jedisct1/libsodium/releases/download/1.0.19-RELEASE/libsodium-1.0.19.tar.gz
 RUN tar -xzvf libsodium-1.0.19.tar.gz
 WORKDIR /build/libsodium-stable
 RUN ./configure --disable-shared --enable-static

--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.23.0-bullseye
 
 # build libsodium (dep of libzmq)
 WORKDIR /build
-RUN wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.19.tar.gz
+RUN wget https://github.com/jedisct1/libsodium/releases/download/1.0.19-RELEASE/libsodium-1.0.19.tar.gz
 RUN tar -xzvf libsodium-1.0.19.tar.gz
 WORKDIR /build/libsodium-stable
 RUN ./configure --disable-shared --enable-static


### PR DESCRIPTION
# Description

https://github.com/teslamotors/fleet-telemetry/pull/345 and https://github.com/teslamotors/fleet-telemetry/pull/346
didn't fix the issue. Upon investigating more. Looks like for some reason, latest image is having libsodium errors. Pinning release pipeline to old image and also reverting commits which didn't fix the issue

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
