### PR TITLE
Always use latest go minor versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start by building the application.
-FROM golang:1.23.0-bullseye AS build
+FROM golang:1.23-bullseye AS build
 
 # build libsodium (dep of libzmq)
 WORKDIR /build


### PR DESCRIPTION
# Description

Stay on the go 1.23 series, but default to the latest released minor version. This way we're always pulling in the latest bug and security fixes. Already running this in our production setup without issues. Just looking to upstream it.

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
