### PR TITLE
chore: remove deprecated field in ginkgo

### DIFF
--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -1,16 +1,14 @@
 package integration_test
 
 import (
-	"testing"
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"testing"
 
 	types "github.com/onsi/ginkgo/v2/types"
 )
 
 func TestTelemetry(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Integration Suite Tests", types.ReporterConfig{SlowSpecThreshold: 10 * time.Second})
+	RunSpecs(t, "Integration Suite Tests", types.ReporterConfig{})
 }


### PR DESCRIPTION
# Description

This field was deprecated in ginkgo v2, as specified here https://github.com/onsi/ginkgo/blob/v2.4.0/types/config.go#L229
and also in https://github.com/onsi/ginkgo/issues/799 


## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
