### PR TITLE
test: update golang version

### DIFF
--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -1,5 +1,5 @@
 # build executable and run integration tests
-FROM golang:1.23.0-bullseye
+FROM golang:1.23-bullseye
 
 # build libsodium (dep of libzmq)
 WORKDIR /build


### PR DESCRIPTION
# Description

I saw that PR being merged https://github.com/teslamotors/fleet-telemetry/pull/366
If we use `1.23` and not `1.23.0` we should also use the same version for test, in order to test and deploy at the same version.

But personally I do prefer fixed version to prevent any breaking build on a patch update.

Fixes # (issue)

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
