### PR TITLE
Add semi-truck only comment to LifetimeEnergyUsedDrive

### DIFF
--- a/protos/vehicle_data.pb.go
+++ b/protos/vehicle_data.pb.go
@@ -127,7 +127,7 @@ const (
 	Field_Deprecated_2                              Field = 100
 	Field_CruiseSetSpeed                            Field = 101
 	Field_LifetimeEnergyUsed                        Field = 102
-	Field_LifetimeEnergyUsedDrive                   Field = 103
+	Field_LifetimeEnergyUsedDrive                   Field = 103 // Semi-truck only
 	Field_SemitruckTractorParkBrakeStatus           Field = 104 // Semi-truck only
 	Field_SemitruckTrailerParkBrakeStatus           Field = 105 // Semi-truck only
 	Field_BrakePedalPos                             Field = 106

--- a/protos/vehicle_data.proto
+++ b/protos/vehicle_data.proto
@@ -110,7 +110,7 @@ enum Field {
   Deprecated_2 = 100;
   CruiseSetSpeed = 101;
   LifetimeEnergyUsed = 102;
-  LifetimeEnergyUsedDrive = 103;
+  LifetimeEnergyUsedDrive = 103; // Semi-truck only
   SemitruckTractorParkBrakeStatus = 104;  // Semi-truck only
   SemitruckTrailerParkBrakeStatus = 105;  // Semi-truck only
   BrakePedalPos = 106;


### PR DESCRIPTION
# Description

Add comment showing LifetimeEnergyUsedDrive is Semi-only

Fixes # (issue)

## Type of change

Please select all options that apply to this change:

- [X] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [X] I have made corresponding updates to the documentation.
