### PR TITLE
bump to debian 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV CGO_LDFLAGS="-lstdc++"
 RUN make
 
 # hadolint ignore=DL3006
-FROM gcr.io/distroless/cc-debian11:nonroot
+FROM gcr.io/distroless/cc-debian12:nonroot
 WORKDIR /
 COPY --from=build /go/bin/fleet-telemetry /
 

--- a/Dockerfile.integration
+++ b/Dockerfile.integration
@@ -1,6 +1,6 @@
 # start the fleet-telemetry server
 # hadolint ignore=DL3006
-FROM gcr.io/distroless/cc-debian11
+FROM gcr.io/distroless/cc-debian12
 WORKDIR /
 
 COPY --from=fleet-telemetry-integration-tests /go/bin/fleet-telemetry /


### PR DESCRIPTION
# Description

turns out debian 11 is outdated and has not been supported by the GCR distroless team [since Sep 2024]

We have been running this on our own system without issues, just looking to upstream this update.

[since Sep 2024]: https://github.com/GoogleContainerTools/distroless/pull/1656

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [X] My code follows the style of this project.
- [X] I have performed a self-review of my code.
- [ ] ~I have made corresponding updates to the documentation.~
- [ ] ~I have added/updated unit tests to cover my changes.~
- [ ] ~I have added/updated integration tests to cover my changes.~
