### PR TITLE
Docs: Annotate ModuleTemp fields as double in proto

### DIFF
--- a/protos/vehicle_data.proto
+++ b/protos/vehicle_data.proto
@@ -36,6 +36,13 @@ enum Field {
   NumBrickVoltageMin = 26;
   BrickVoltageMin = 27;
   NumModuleTempMax = 28;
+
+  // NOTE:
+  // Tesla Fleet Telemetry official documentation lists ModuleTempMax and ModuleTempMin as integers:
+  // https://developer.tesla.com/docs/fleet-api/fleet-telemetry/available-data#vehicle-data
+  //
+  // However, actual telemetry reports these values as double (fractional temperatures).
+  // Developers should expect floating-point values here.   
   ModuleTempMax = 29;
   NumModuleTempMin = 30;
   ModuleTempMin = 31;


### PR DESCRIPTION
# DescriptionAdded clarification comments to `ModuleTempMin` (ID 31) and `ModuleTempMax` (ID 29) in `protos/vehicle_data.proto`.

As reported in the related issue, the official documentation lists these fields as `Integer`, but actual telemetry data from vehicles returns `double` (floating point) values. This update documents the discrepancy directly in the source of truth to assist developers integrating with the API.

Fixes #428

## Type of change:

* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Documentation update

# Checklist:

* [x] My code follows the style of this project.
* [x] I have performed a self-review of my code.
* [x] I have made corresponding updates to the documentation.
* [ ] I have added/updated unit tests to cover my changes.
* [ ] I have added/updated integration tests to cover my changes.