### PR TITLE
Allow rate limiter to actually be disabled

### DIFF
--- a/server/streaming/socket.go
+++ b/server/streaming/socket.go
@@ -186,9 +186,14 @@ func (sm *SocketManager) ProcessTelemetry(serializer *telemetry.BinarySerializer
 	go sm.writer()
 	var rl *rate.RateLimiter
 
-	if sm.config.RateLimit != nil && sm.config.RateLimit.Enabled {
+	if sm.config.RateLimit == nil {
+		// No rate limit config - apply default
+		rl = rate.New(100, 60*time.Second)
+	} else if sm.config.RateLimit.Enabled {
+		// Rate limiting explicitly enabled with custom values
 		rl = rate.New(sm.config.RateLimit.MessageLimit, sm.config.RateLimit.MessageIntervalTimeSecond)
 	}
+	// else: RateLimit config exists but Enabled is false - no rate limiting
 
 	var rateLimitStartTime time.Time
 	messagesRateLimited := 0


### PR DESCRIPTION
# Description

When rate_limit.enabled is set to false in the config, rate_limit_exceeded logs and metrics were still being emitted. This occurred because:

  1. A default rate limiter (100 messages per 60 seconds) was created even when rate limiting was disabled
  2. The rate limiter check ran on every message regardless of the config setting
  3. Messages were not dropped, but logs were written suggesting they were

  This fix ensures the rate limiter is only created when explicitly enabled, and the rate limit logic is skipped when disabled.

Fixes # (issue)

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
