### PR TITLE
docs: document prometheus_metrics_host and profiler_host config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ For ease of installation and operation, run Fleet Telemetry on Kubernetes or a s
   "transmit_decoded_records": bool - if true, transmit JSON to dispatchers instead of proto.
   "monitoring": {
     "prometheus_metrics_port": int,
+    "prometheus_metrics_host": string - address to bind the Prometheus metrics server (default "127.0.0.1"; set to "0.0.0.0" for Kubernetes liveness/readiness probes),
     "profiler_port": int,
+    "profiler_host": string - address to bind the profiler server (default "127.0.0.1"),
     "profiling_path": string - out path,
     "statsd": { if not using prometheus
       "host": string - host:port of the statsd server,


### PR DESCRIPTION
v0.9.0 tightened the default bind address for the Prometheus metrics and profiler servers from `0.0.0.0` to `127.0.0.1` as a security hardening measure. That change broke Kubernetes liveness and readiness probes, which connect via the pod IP rather than localhost.

The `MonitoringConfig` struct already has `PrometheusMetricsHost` and `ProfilerHost` fields to override this default, but neither field was documented in the README config reference, so operators had no way to discover them.

This adds both fields to the config reference table with a brief note explaining when to use `0.0.0.0`.

Fixes #458