### PR TITLE
streaming: stop processing records that fail to parse as UnknownMessageType

### DIFF
--- a/server/streaming/socket.go
+++ b/server/streaming/socket.go
@@ -264,6 +264,7 @@ func (sm *SocketManager) ParseAndProcessRecord(serializer *telemetry.BinarySeria
 			sm.logger.ErrorLog("unknown_message_type_error", err, logInfo)
 			metricsRegistry.unknownMessageTypeErrorCount.Inc(map[string]string{"msg_type": string(typedError.GuessedType)})
 			sm.respondToVehicle(record, nil) // respond to the client message was accepted so they are not resending it over and over
+			return
 		default:
 			sm.respondToVehicle(record, err)
 			return

--- a/server/streaming/socket_test.go
+++ b/server/streaming/socket_test.go
@@ -84,6 +84,11 @@ var _ = Describe("Socket test", func() {
 			Expect(envelope.MessageType()).To(Equal(tesla.MessageFlatbuffersStreamAck))
 			lastLogEntry := hook.LastEntry()
 			Expect(lastLogEntry.Message).To(ContainSubstring("unknown_message_type_error"))
+
+			// A message that fails to parse must not be processed as a record:
+			// it should be acknowledged once and dropped, not fall through to
+			// the dispatch path (which would record stats and ack a second time).
+			Expect(sm.RecordsStats).To(BeEmpty())
 		})
 
 		It("returns error for unknown topic and unmatched sender", func() {


### PR DESCRIPTION
In `ParseAndProcessRecord`, the three error branches are meant to acknowledge the client and stop. `UnauthorizedSenderIDError` and the `default` case both `return` after responding, but the `UnknownMessageType` case does not:

```go
case *telemetry.UnknownMessageType:
    logInfo["msg_txid"] = typedError.Txid
    logInfo["msg_type"] = string(typedError.GuessedType)
    sm.logger.ErrorLog("unknown_message_type_error", err, logInfo)
    metricsRegistry.unknownMessageTypeErrorCount.Inc(map[string]string{"msg_type": string(typedError.GuessedType)})
    sm.respondToVehicle(record, nil) // respond to the client message was accepted so they are not resending it over and over
default:
    ...
```

Because there is no `return`, execution falls out of the switch and continues into the record-processing path:

```go
sm.ReportMetricBytesPerRecords(record.TxType, record.Length())
sm.processRecord(record)
if !sm.reliableAck(record) {
    sm.respondToVehicle(record, nil)
}
```

A message that failed to deserialize comes back from `guessError` with an empty `TxType`, so for such a message this means:

- it is counted in `RecordsStats` and in the `record_total` / `record_size_bytes_total` metrics,
- it is passed to `Dispatch` and increments `dispatch_total` with an empty `record_type` label (the dispatch itself is a no-op since no producers are registered for ""), and
- it is acknowledged a second time on the write channel.

Adding the missing `return` makes the case behave like the other two: acknowledge once and drop the message.

I tightened the existing "unknown message type returns error" test to assert `sm.RecordsStats` stays empty. That assertion fails on the current code (the fall-through records stats for the unparseable message) and passes with the fix.