### PR TITLE
Prevent VIN spoofing in connectivity records

### DIFF
--- a/telemetry/record.go
+++ b/telemetry/record.go
@@ -190,6 +190,7 @@ func (record *Record) applyProtoRecordTransforms() error {
 		if err != nil {
 			return err
 		}
+		message.Vin = record.Vin
 		record.PayloadBytes, err = proto.Marshal(message)
 		record.protoMessage = message
 		return err

--- a/telemetry/record_test.go
+++ b/telemetry/record_test.go
@@ -311,6 +311,40 @@ var _ = Describe("Socket handler test", func() {
 			}),
 		)
 
+		It("overwrites a spoofed connectivity body VIN with the authenticated cert VIN", func() {
+			const certVin = "certVin"
+			const spoofedVin = "spoofedVin"
+			payloadBytes, err := proto.Marshal(&protos.VehicleConnectivity{Vin: spoofedVin})
+			Expect(err).NotTo(HaveOccurred())
+
+			message := messages.StreamMessage{
+				TXID:         []byte("1234"),
+				DeviceID:     []byte(certVin),
+				SenderID:     []byte(fmt.Sprintf("vehicle_device.%s", certVin)),
+				MessageTopic: []byte("connectivity"),
+				Payload:      payloadBytes,
+			}
+			recordMsg, err := message.ToBytes()
+			Expect(err).NotTo(HaveOccurred())
+
+			serializer = telemetry.NewBinarySerializer(
+				&telemetry.RequestIdentity{
+					DeviceID: certVin,
+					SenderID: fmt.Sprintf("vehicle_device.%s", certVin),
+				},
+				map[string][]telemetry.Producer{"D4": nil},
+				logger,
+			)
+
+			record, err := telemetry.NewRecord(serializer, recordMsg, "1", true)
+			Expect(err).NotTo(HaveOccurred())
+
+			output, ok := record.GetProtoMessage().(*protos.VehicleConnectivity)
+			Expect(ok).To(BeTrue())
+			Expect(output.GetVin()).To(Equal(certVin))
+			Expect(output.GetVin()).NotTo(Equal(spoofedVin))
+		})
+
 		It("json payload returns valid data when transmitDecodedRecords is false", func() {
 			message := messages.StreamMessage{TXID: []byte("1234"), SenderID: []byte("vehicle_device.42"), MessageTopic: []byte("V"), Payload: generatePayload("cybertruck", "42", nil)}
 			recordMsg, err := message.ToBytes()


### PR DESCRIPTION
## Summary

The connectivity arm of applyProtoRecordTransforms did not overwrite the payload's VIN with the authenticated (cert-derived) VIN, unlike the V, alerts, and errors arms. A vehicle with a valid client cert could submit a VehicleConnectivity payload wiith an arbitrary VIN that propagated to all backends. Stamp record.Vin to the message and add a regression test.