### PR TITLE
Allow overriding the Redis password via REDIS_PASSWORD

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ For ease of installation and operation, run Fleet Telemetry on Kubernetes or a s
   "redis": { // Redis pub/sub config
     "addrs": ["redis:6379"], // one or more addresses (cluster/sentinel supported)
     "username": string - optional,
-    "password": string - optional,
+    "password": string - optional; overridden by the REDIS_PASSWORD environment variable when set,
     "db": int - optional,
     "subscriber_set_prefix": string - optional; names the per-VIN subscriber sorted set. When empty, the sorted set is not consulted,
     "publish_vin_topics": bool - additionally publish each record to the VIN channel namespace_topic_{vin},

--- a/config/config.go
+++ b/config/config.go
@@ -191,10 +191,15 @@ func (r *Redis) options() (*goredis.UniversalOptions, error) {
 	if err != nil {
 		return nil, err
 	}
+	password := r.Password
+	if envPassword := os.Getenv("REDIS_PASSWORD"); envPassword != "" {
+		password = envPassword
+	}
+
 	options := &goredis.UniversalOptions{
 		Addrs:     r.Addrs,
 		Username:  r.Username,
-		Password:  r.Password,
+		Password:  password,
 		DB:        r.DB,
 		TLSConfig: tlsConfig,
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -223,6 +223,30 @@ var _ = Describe("Test full application config", func() {
 		})
 	})
 
+	Context("configure redis", func() {
+		AfterEach(func() {
+			_ = os.Unsetenv("REDIS_PASSWORD")
+		})
+
+		It("uses the password from config when REDIS_PASSWORD is unset", func() {
+			redis := &Redis{Addrs: []string{"redis:6379"}, Password: "config-password"}
+
+			options, err := redis.options()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(options.Password).To(Equal("config-password"))
+		})
+
+		It("overrides the password with the REDIS_PASSWORD env variable when set", func() {
+			err := os.Setenv("REDIS_PASSWORD", "env-password")
+			Expect(err).NotTo(HaveOccurred())
+			redis := &Redis{Addrs: []string{"redis:6379"}, Password: "config-password"}
+
+			options, err := redis.options()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(options.Password).To(Equal("env-password"))
+		})
+	})
+
 	Context("VinsToTrack", func() {
 
 		AfterEach(func() {


### PR DESCRIPTION
# Description

- The Redis producer reads its password from the REDIS_PASSWORD environment variable when set, falling back to the config-file value.


## Type of change

Please select all options that apply to this change:

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [X] My code follows the style of this project.
- [X] I have performed a self-review of my code.
- [X] I have made corresponding updates to the documentation.
- [X] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
