### PR TITLE
Add Redis TLS server name and cluster mode support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,9 @@ import (
 	_ "embed" //Used for default CAs
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -155,13 +157,15 @@ type Kinesis struct {
 
 // Redis is a configuration for the Redis pub/sub producer.
 type Redis struct {
-	Addrs          []string      `json:"addrs"`
-	Username       string        `json:"username,omitempty"`
-	Password       string        `json:"password,omitempty"`
-	DB             int           `json:"db,omitempty"`
-	TLS            *TLS          `json:"tls,omitempty"`
-	Pool           *RedisPool    `json:"pool,omitempty"`
-	PublishTimeout time.Duration `json:"publish_timeout,omitempty"`
+	Addrs                 []string      `json:"addrs"`
+	Username              string        `json:"username,omitempty"`
+	Password              string        `json:"password,omitempty"`
+	DB                    int           `json:"db,omitempty"`
+	TLS                   *TLS          `json:"tls,omitempty"`
+	OverrideTLSServerName bool          `json:"override_tls_server_name,omitempty"`
+	Pool                  *RedisPool    `json:"pool,omitempty"`
+	PublishTimeout        time.Duration `json:"publish_timeout,omitempty"`
+	ClusterMode           bool          `json:"cluster_mode,omitempty"`
 
 	// PublishVINTopics, when true, always publishes on the VIN set-key
 	// channel.
@@ -191,6 +195,9 @@ func (r *Redis) options() (*goredis.UniversalOptions, error) {
 	if err != nil {
 		return nil, err
 	}
+	if r.OverrideTLSServerName && tlsConfig != nil {
+		tlsConfig.ServerName = r.getServerName()
+	}
 	password := r.Password
 	if envPassword := os.Getenv("REDIS_PASSWORD"); envPassword != "" {
 		password = envPassword
@@ -202,6 +209,9 @@ func (r *Redis) options() (*goredis.UniversalOptions, error) {
 		Password:  password,
 		DB:        r.DB,
 		TLSConfig: tlsConfig,
+	}
+	if r.ClusterMode {
+		options.IsClusterMode = true
 	}
 	if r.Pool != nil {
 		options.PoolSize = r.Pool.PoolSize
@@ -215,6 +225,24 @@ func (r *Redis) options() (*goredis.UniversalOptions, error) {
 		options.ConnMaxLifetime = r.Pool.ConnMaxLifetime
 	}
 	return options, nil
+}
+
+func (r *Redis) getServerName() string {
+	if len(r.Addrs) == 0 {
+		return ""
+	}
+
+	addr := r.Addrs[0]
+	// A scheme-qualified addr (e.g. rediss://host:6379) parses cleanly here.
+	if parsedURL, err := url.Parse(addr); err == nil && parsedURL.Hostname() != "" {
+		return parsedURL.Hostname()
+	}
+	// A bare host:port (the common case) is mis-parsed by url.Parse as
+	// scheme:opaque, so strip the port directly.
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		return host
+	}
+	return addr
 }
 
 //go:embed files/eng_ca.crt

--- a/datastore/redis/redis.go
+++ b/datastore/redis/redis.go
@@ -86,6 +86,9 @@ func NewProducer(options *redis.UniversalOptions, publishTimeout time.Duration, 
 		timeout:             timeout,
 	}
 
+	if err := client.Ping(context.Background()).Err(); err != nil {
+		return nil, fmt.Errorf("redis_connect_error %w", err)
+	}
 	producer.logger.ActivityLog("redis_registered", logrus.LogInfo{"namespace": namespace, "publish_vin_topics": publishVINTopics, "subscriber_set_prefix": subscriberSetPrefix})
 	return producer, nil
 }
@@ -97,7 +100,7 @@ func (p *Producer) Produce(entry *telemetry.Record) {
 	payload := entry.Payload()
 	channels, err := p.channelsForRecord(entry)
 	if err != nil {
-		p.ReportError("redis_err", err, logrus.LogInfo{"channel": "", "txid": entry.Txid})
+		p.ReportError("redis_err", err, logrus.LogInfo{"vin": entry.Vin, "tx_type": entry.TxType, "txid": entry.Txid})
 		metricsRegistry.errorCount.Inc(map[string]string{"record_type": entry.TxType})
 		return
 	}
@@ -105,7 +108,7 @@ func (p *Producer) Produce(entry *telemetry.Record) {
 		ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
 		defer cancel()
 		if err := p.client.Publish(ctx, channel, payload).Err(); err != nil {
-			p.ReportError("redis_err", err, logrus.LogInfo{"channel": channel, "txid": entry.Txid})
+			p.ReportError("redis_err", err, logrus.LogInfo{"channel": channel, "vin": entry.Vin, "tx_type": entry.TxType, "txid": entry.Txid})
 			metricsRegistry.errorCount.Inc(map[string]string{"record_type": entry.TxType})
 			return
 		}


### PR DESCRIPTION
# Description
- Add set_tls_server_name to override the TLS server name (SNI) on the Redis client connection.
- Add cluster_mode to run the producer against a Redis Cluster.
- Include vin and tx_type in Redis publish-error logs.

## Type of change

Please select all options that apply to this change:

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [X] My code follows the style of this project.
- [X] I have performed a self-review of my code.
- [X] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
