### PR TITLE
Confine zmq socket to a single send loop to fix concurrent access

### DIFF
--- a/datastore/zmq/zmq.go
+++ b/datastore/zmq/zmq.go
@@ -57,23 +57,37 @@ var (
 // ZMQ publisher socket.
 const MonitorSocketAddr = "inproc://zmq_socket_monitor.rep"
 
+// recordChanBufferSize bounds how many records can wait for the send loop
+// before Produce applies backpressure to its caller.
+const recordChanBufferSize = 1000
+
 // Producer implements the telemetry.Producer interface by publishing to a
 // bound zmq socket.
 type Producer struct {
 	namespace          string
 	ctx                context.Context
+	cancel             context.CancelFunc
 	sock               *zmq4.Socket
 	logger             *logrus.Logger
 	airbrakeHandler    *airbrake.Handler
 	ackChan            chan (*telemetry.Record)
 	reliableAckTxTypes map[string]interface{}
+	recordChan         chan *telemetry.Record
+	wg                 sync.WaitGroup
+	closeOnce          sync.Once
 }
 
 // Produce the record to the socket.
 func (p *Producer) Produce(rec *telemetry.Record) {
-	if p.ctx.Err() != nil {
-		return
+	select {
+	case p.recordChan <- rec:
+	case <-p.ctx.Done():
 	}
+}
+
+// send writes a single record to the socket.
+// It must only ever be called from sendLoop, which owns the socket.
+func (p *Producer) send(rec *telemetry.Record) {
 	nBytes, err := p.sock.SendMessage(telemetry.BuildTopicName(p.namespace, rec.TxType), rec.Payload())
 	if err != nil {
 		metricsRegistry.errorCount.Inc(map[string]string{"record_type": rec.TxType})
@@ -85,21 +99,37 @@ func (p *Producer) Produce(rec *telemetry.Record) {
 	metricsRegistry.publishCount.Inc(map[string]string{"record_type": rec.TxType})
 }
 
+// sendLoop is the single goroutine that owns and writes to the socket.
+func (p *Producer) sendLoop() {
+	defer p.wg.Done()
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		case rec := <-p.recordChan:
+			p.send(rec)
+		}
+	}
+}
+
 // ReportError to airbrake and logger
 func (p *Producer) ReportError(message string, err error, logInfo logrus.LogInfo) {
 	p.airbrakeHandler.ReportLogMessage(logrus.ERROR, message, err, logInfo)
 	p.logger.ErrorLog(message, err, logInfo)
 }
 
-// Close the underlying socket.
+// Close stops the send loop and then closes the underlying socket.
 func (p *Producer) Close() error {
-	if p.sock != nil {
-		if err := p.sock.Close(); err != nil {
-			return err
+	var err error
+	p.closeOnce.Do(func() {
+		p.cancel()
+		p.wg.Wait()
+		if p.sock != nil {
+			err = p.sock.Close()
+			p.sock = nil
 		}
-	}
-	p.sock = nil
-	return nil
+	})
+	return err
 }
 
 // ProcessReliableAck sends to ackChan if reliable ack is configured
@@ -175,15 +205,24 @@ func NewProducer(ctx context.Context, config *Config, metrics metrics.MetricColl
 		return
 	}
 
-	return &Producer{
+	ctx, cancel := context.WithCancel(ctx)
+
+	p := &Producer{
 		namespace:          namespace,
 		ctx:                ctx,
+		cancel:             cancel,
 		sock:               sock,
 		logger:             logger,
 		airbrakeHandler:    airbrakeHandler,
 		ackChan:            ackChan,
 		reliableAckTxTypes: reliableAckTxTypes,
-	}, nil
+		recordChan:         make(chan *telemetry.Record, recordChanBufferSize),
+	}
+
+	p.wg.Add(1)
+	go p.sendLoop()
+
+	return p, nil
 }
 
 // logSocketInBackground logs the socket activity in the background.

--- a/datastore/zmq/zmq_suite_test.go
+++ b/datastore/zmq/zmq_suite_test.go
@@ -1,0 +1,13 @@
+package zmq_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestZMQ(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ZMQ Suite")
+}

--- a/datastore/zmq/zmq_test.go
+++ b/datastore/zmq/zmq_test.go
@@ -1,0 +1,202 @@
+package zmq_test
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pebbe/zmq4"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/teslamotors/fleet-telemetry/datastore/zmq"
+	logrus "github.com/teslamotors/fleet-telemetry/logger"
+	"github.com/teslamotors/fleet-telemetry/messages"
+	"github.com/teslamotors/fleet-telemetry/metrics"
+	"github.com/teslamotors/fleet-telemetry/protos"
+	"github.com/teslamotors/fleet-telemetry/server/airbrake"
+	"github.com/teslamotors/fleet-telemetry/telemetry"
+)
+
+var _ = Describe("ZMQ Producer", func() {
+	var (
+		mockLogger    *logrus.Logger
+		mockCollector metrics.MetricCollector
+		mockAirbrake  *airbrake.Handler
+		mockConfig    *zmq.Config
+		serializer    *telemetry.BinarySerializer
+	)
+
+	BeforeEach(func() {
+		mockLogger, _ = logrus.NoOpLogger()
+		mockCollector = metrics.NewCollector(nil, mockLogger)
+		mockAirbrake = airbrake.NewAirbrakeHandler(nil)
+		mockConfig = &zmq.Config{Addr: "tcp://127.0.0.1:*"}
+
+		serializer = telemetry.NewBinarySerializer(
+			&telemetry.RequestIdentity{
+				DeviceID: "TEST123",
+				SenderID: "vehicle_device.TEST123",
+			},
+			map[string][]telemetry.Producer{},
+			mockLogger,
+		)
+	})
+
+	newRecord := func() *telemetry.Record {
+		payload := &protos.Payload{Vin: "TEST123"}
+		payloadBytes, err := proto.Marshal(payload)
+		Expect(err).NotTo(HaveOccurred())
+
+		message := messages.StreamMessage{
+			TXID:         []byte("1234"),
+			SenderID:     []byte("vehicle_device.TEST123"),
+			MessageTopic: []byte("V"),
+			Payload:      payloadBytes,
+		}
+		msgBytes, err := message.ToBytes()
+		Expect(err).NotTo(HaveOccurred())
+		record, err := telemetry.NewRecord(serializer, msgBytes, "1", true)
+		Expect(err).NotTo(HaveOccurred())
+		return record
+	}
+
+	It("handles concurrent Produce calls safely", func() {
+		producer, err := zmq.NewProducer(
+			context.Background(),
+			mockConfig,
+			mockCollector,
+			"test_namespace",
+			mockAirbrake,
+			nil,
+			nil,
+			mockLogger,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() {
+			Expect(producer.Close()).To(Succeed())
+		}()
+
+		rec := newRecord()
+
+		const goroutines = 50
+		const perGoroutines = 100
+		var wg sync.WaitGroup
+		for range goroutines {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for range perGoroutines {
+					producer.Produce(rec)
+				}
+			}()
+		}
+		wg.Wait()
+	})
+
+	It("does not block or panic when Close races with Produce", func() {
+		producer, err := zmq.NewProducer(
+			context.Background(),
+			mockConfig,
+			mockCollector,
+			"test_namespace",
+			mockAirbrake,
+			nil,
+			nil,
+			mockLogger,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		rec := newRecord()
+
+		const goroutines = 10
+		const perGoroutines = 1000
+		var wg sync.WaitGroup
+
+		for range goroutines {
+			wg.Add(1)
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+				for range perGoroutines {
+					producer.Produce(rec)
+				}
+			}()
+		}
+
+		Expect(producer.Close()).To(Succeed())
+
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+		Eventually(done, "5s").Should(BeClosed())
+	})
+
+	It("can be closed more than once", func() {
+		producer, err := zmq.NewProducer(
+			context.Background(),
+			mockConfig,
+			mockCollector,
+			"test_namespace",
+			mockAirbrake,
+			nil,
+			nil,
+			mockLogger,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(producer.Close()).To(Succeed())
+		Expect(producer.Close()).To(Succeed())
+	})
+
+	It("delivers published records to a subscriber with intact framing", func() {
+		addr := "inproc://zmq-delivery-test"
+		cfg := &zmq.Config{Addr: addr}
+		producer, err := zmq.NewProducer(
+			context.Background(),
+			cfg,
+			mockCollector,
+			"test_namespace",
+			mockAirbrake,
+			nil,
+			nil,
+			mockLogger,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() {
+			Expect(producer.Close()).To(Succeed())
+		}()
+
+		sub, err := zmq4.NewSocket(zmq4.SUB)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = sub.Close() }()
+		Expect(sub.SetSubscribe("")).To(Succeed())
+		Expect(sub.Connect(addr)).To(Succeed())
+
+		rec := newRecord()
+		expectedTopic := telemetry.BuildTopicName("test_namespace", rec.TxType)
+		expectedPayload := rec.Payload()
+
+		Expect(sub.SetRcvtimeo(100 * time.Millisecond)).To(Succeed())
+
+		// warm up: publish one at a time until the first message gets through
+		// a successful receive proves the subscription has reached the publisher
+		Eventually(func() bool {
+			producer.Produce(rec)
+			_, err := sub.RecvMessageBytes(0)
+			return err == nil
+		}, "5s", "10ms").Should(BeTrue())
+
+		for range 5 {
+			producer.Produce(rec)
+			frames, err := sub.RecvMessageBytes(0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(frames).To(HaveLen(2))
+			Expect(string(frames[0])).To(Equal(expectedTopic))
+			Expect(frames[1]).To(Equal(expectedPayload))
+		}
+	})
+})


### PR DESCRIPTION
# Description

`zmq.Producer` shared one `PUB` socket across every per-connection goroutine, all calling `SendMessage` with no synchronization. ZMQ's API reference is explicit (also [ref](https://pkg.go.dev/github.com/pebbe/zmq4#NewSocket)):

> "ØMQ sockets are not thread safe. Applications MUST NOT use a socket from multiple threads except after migrating a socket from one thread to another with a full fence memory barrier."

`PUB` is not one of ZMQ's thread-safe socket types.

## Why not a mutex or a thread-safe socket type

- Mutex: correct, but the socket stays reachable from N goroutines and safety depends on every caller remembering to lock. 
- Thread-safe socket type (`RADIO` / `DISH`): still draft API, and wire-incompatible. Exact-match groups instead of `SUB` prefix filtering, no multipart. Would break every downstream consumer.

## Ack side-effect

`ProcessReliableAck` now runs on the single sendLoop. `AckChan` is unbuffered with one `handleAcks` consumer, so in principle a stalled consumer could backpressure all zmq producers (before: just one connection). In practice this should be fine. Acks are a quick websocket write, so the consumer keeps up, and the worst case is a slowdown, never corruption. Easily addressed if it ever shows (buffer AckChan / add workers).


## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [x] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
