### PR TITLE
Increase json log timestamp precision

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mattn/go-colorable"
 	"github.com/sirupsen/logrus"
@@ -170,7 +171,7 @@ func (l *Logger) ErrorLog(message string, err error, info LogInfo) {
 // SetJSONFormatter sets logger to emit JSON or false => TextFormatter
 func (l *Logger) SetJSONFormatter(json bool) {
 	if json {
-		logrus.SetFormatter(&logrus.JSONFormatter{})
+		logrus.SetFormatter(&logrus.JSONFormatter{TimestampFormat: time.RFC3339Nano})
 	} else {
 		logrus.SetFormatter(&logrus.TextFormatter{})
 	}

--- a/telemetry/serializer.go
+++ b/telemetry/serializer.go
@@ -57,7 +57,7 @@ func (bs *BinarySerializer) Deserialize(msg []byte, socketID string) (record *Re
 	record.Txid = string(streamMessage.TXID)
 	record.Vin = string(bs.RequestIdentity.DeviceID)
 	record.PayloadBytes = streamMessage.Payload
-	record.ReceivedTimestamp = time.Now().Unix() * 1000
+	record.ReceivedTimestamp = time.Now().UnixMilli()
 	record.DeviceClientVersion = bs.RequestIdentity.DeviceClientVersion
 
 	if _, ok := bs.DispatchRules[streamMessage.Topic()]; ok {

--- a/telemetry/serializer_test.go
+++ b/telemetry/serializer_test.go
@@ -3,6 +3,7 @@ package telemetry_test
 import (
 	"errors"
 	"reflect"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -178,7 +179,7 @@ var _ = Describe("BinarySerializer", func() {
 			gotRecord, err := bs.Deserialize(msgBytes, tt.args.socketID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(gotRecord.ReceivedTimestamp).NotTo(Equal(0))
+			Expect(gotRecord.ReceivedTimestamp).To(BeNumerically("<=", time.Now().UnixMilli(), 1000))
 
 			gotRecord.ReceivedTimestamp = 0
 			tt.wantRecord.Serializer = bs


### PR DESCRIPTION
# Description

Configure JSON log formatter to use nanosecond precision.

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [x] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
