### PR TITLE
Bump Go 1.26, Errbit, and pin monitoring images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,9 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.23.0
+        go-version: 1.26.x
 
     - name: Set up protoc
       run: |
@@ -41,9 +41,9 @@ jobs:
       run: sudo apt update -y && sudo apt upgrade -y && sudo apt install libsodium-dev libzmq3-dev
     
     - name: Setup golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v9
       with:
-        version: v1.61.0
+        version: v2.12.2
 
     - name: Linter passes
       run: make linters

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,51 +1,51 @@
 ---
+version: "2"
+
 run:
   timeout: 4m
 
-issues:
-  exclude-dirs:
-    - temp
-
 linters:
+  # errcheck, govet, staticcheck, unused are enabled by default.
+  # gosimple is now part of staticcheck in v2.
   enable:
-    - errcheck
-    - gofmt
-    - gosimple
-    - govet
     - misspell
     - revive
-    - staticcheck
-    - unused
+  settings:
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+          arguments:
+            - allowedPackages:
+                - "github.com/onsi/ginkgo"
+                - "github.com/onsi/ginkgo/v2"
+                - "github.com/onsi/gomega"
+        - name: empty-block
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
+        - name: exported
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: package-comments
+          disabled: true
+        - name: range
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: superfluous-else
+        - name: time-naming
+        - name: unexported-return
+        - name: unreachable-code
+        - name: unused-parameter
+        - name: var-declaration
+        - name: var-naming
+  exclusions:
+    paths:
+      - temp
 
-linters-settings:
-  revive:
-    rules:
-      - name: blank-imports
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: dot-imports
-        arguments:
-          - allowedPackages:
-            - "github.com/onsi/ginkgo"
-            - "github.com/onsi/ginkgo/v2"
-            - "github.com/onsi/gomega"
-      - name: empty-block
-      - name: error-naming
-      - name: error-return
-      - name: error-strings
-      - name: errorf
-      - name: exported
-      - name: increment-decrement
-      - name: indent-error-flow
-      - name: package-comments
-        disabled: true
-      - name: range
-      - name: receiver-naming
-      - name: redefines-builtin-id
-      - name: superfluous-else
-      - name: time-naming
-      - name: unexported-return
-      - name: unreachable-code
-      - name: unused-parameter
-      - name: var-declaration
-      - name: var-naming
+formatters:
+  enable:
+    - goimports

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start by building the application.
-FROM golang:1.23-bullseye AS build
+FROM golang:1.26-bookworm AS build
 
 # build libsodium (dep of libzmq)
 WORKDIR /build
@@ -28,7 +28,7 @@ ENV CGO_LDFLAGS="-lstdc++"
 RUN make
 
 # hadolint ignore=DL3006
-FROM gcr.io/distroless/cc-debian11:nonroot
+FROM gcr.io/distroless/cc-debian12:nonroot
 WORKDIR /
 COPY --from=build /go/bin/fleet-telemetry /
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # enabling gofmt and golint since by default they're not enabled by golangci-lint
 VERSION           = $(shell go version)
-LINTER			  = golangci-lint run -v $(LINTER_FLAGS) --exclude-use-default=false --timeout $(LINTER_DEADLINE)
+LINTER			  = golangci-lint run -v $(LINTER_FLAGS) --timeout $(LINTER_DEADLINE)
 LINTER_DEADLINE	  = 30s
 LINTER_FLAGS ?=
 ALPHA_IMAGE_NAME=fleet-telemetry-server-aplha:v0.0.1

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ brew install libsodium zmq
 ## Integration Tests
 
 To run the integration tests: `make integration`
-To log into errbit instances, default username is `noreply@example.org` and default password is `test123`
+To log into errbit instances, default username is `noreply@example.org` and default password is `test1234`
 
 ## Building the binary for Linux from Mac ARM64
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,38 +95,49 @@ services:
 
   # Errbit implements airbrake's API, so we can use it to test the airbrake
   errbit:
-    image: errbit/errbit:v0.8.0
+    image: errbit/errbit:0.11.2
     platform: linux/amd64
     ports:
-      - '48088:8080'
-    command: sh -c "bundle exec rake errbit:bootstrap && bundle exec puma -C config/puma.default.rb"
+      - '48088:80'
+    command: >
+      sh -c "bundle exec rails errbit:bootstrap &&
+             bundle exec rails errbit:init_errbit &&
+             ./bin/thrust ./bin/rails server"
     volumes:
       - ./test/integration/errbit/apps.json:/initialize/apps.json:ro
       - ./test/integration/errbit/site_configs.json:/initialize/site_configs.json:ro
       - ./test/integration/errbit/users.json:/initialize/users.json:ro
-      - ./test/integration/errbit/init_errbit.rake:/app/lib/tasks/init_errbit.rake:ro
+      - ./test/integration/errbit/init_errbit.rake:/rails/lib/tasks/init_errbit.rake:ro
     depends_on:
       mongodb:
         condition: service_healthy
     environment:
-      RACK_ENV: production
-      PORT: 8080
+      RAILS_ENV: production
+      SECRET_KEY_BASE: integration-test-secret-key-base-not-for-production
       MONGO_URL: mongodb://errbit_user:errbit_password@mongodb:27017/errbit
-      # Add these environment variables to control the initialization
       ERRBIT_ADMIN_EMAIL: admin@example.com
       ERRBIT_ADMIN_PASSWORD: password
       ERRBIT_ADMIN_USER: admin
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/up"]
+      start_period: 60s
+      interval: 5s
+      timeout: 10s
+      retries: 20
 
   mongodb:
-    image: mongo:4.1
+    image: mongo:8.2
     ports:
       - '27017:27017'
     environment:
       MONGO_INITDB_ROOT_USERNAME: errbit-admin
       MONGO_INITDB_ROOT_PASSWORD: 42
     healthcheck:
-      test: mongo -u errbit-admin  -p 42  --eval "db.adminCommand('ping')" --quiet
+      test: mongosh -u errbit-admin -p 42 --eval "db.adminCommand('ping')" --quiet
       interval: 5s
+      timeout: 10s
+      retries: 10
+      start_period: 15s
     volumes:
       - ./test/integration/mongodb/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
 
@@ -136,7 +147,7 @@ services:
       - "6379:6379"
 
   prometheus:
-    image: prom/prometheus
+    image: prom/prometheus:v3.13.1
     ports:
       - "19090:9090"
     volumes:
@@ -145,7 +156,7 @@ services:
       - '--config.file=/etc/prometheus/prometheus.yml'
 
   grafana:
-    image: grafana/grafana
+    image: grafana/grafana:13.1.0
     ports:
       - "13000:3000"
     environment:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/teslamotors/fleet-telemetry
 
-go 1.23.0
+go 1.26.0
 
 require (
 	cloud.google.com/go/pubsub v1.30.0

--- a/messages/identity.go
+++ b/messages/identity.go
@@ -76,7 +76,7 @@ var (
 
 // CreateIdentityFromCert given the X509 Cert return a deviceID
 func CreateIdentityFromCert(fullCert *x509.Certificate) (clientType, deviceID string, err error) {
-	deviceID = strings.Replace(fullCert.Subject.CommonName, ".", "-", -1)
+	deviceID = strings.ReplaceAll(fullCert.Subject.CommonName, ".", "-")
 	if _, ok := knownOIDIssuers[fullCert.Issuer.CommonName]; ok {
 		return createIdentifyFromOID(fullCert, deviceID)
 	}

--- a/server/airbrake/airbrake.go
+++ b/server/airbrake/airbrake.go
@@ -56,11 +56,8 @@ func (a *Handler) logMessage(logType logrus.LogType, message string, err error, 
 	if err != nil {
 		notice.Params["error"] = err.Error()
 	}
-	//nolint:gosimple
-	if logInfo != nil {
-		for logKey, logValue := range logInfo {
-			notice.Params[logKey] = logValue
-		}
+	for logKey, logValue := range logInfo {
+		notice.Params[logKey] = logValue
 	}
 	return notice
 }

--- a/server/monitoring/profile_server.go
+++ b/server/monitoring/profile_server.go
@@ -31,10 +31,10 @@ func (p *profileServer) liveProfiler(config *config.Config) func(w http.Response
 		}
 
 		if metrics.EnableProfiler(mode) {
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"result":"mode %v"}`, mode)))
+			_, _ = fmt.Fprintf(w, `{"result":"mode %v"}`, mode)
 		} else {
 			w.WriteHeader(304)
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"result":"mode already %v"}`, mode)))
+			_, _ = fmt.Fprintf(w, `{"result":"mode already %v"}`, mode)
 		}
 	}
 }

--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -1,5 +1,5 @@
 # build executable and run integration tests
-FROM golang:1.23-bullseye
+FROM golang:1.26-bookworm
 
 # build libsodium (dep of libzmq)
 WORKDIR /build

--- a/test/integration/config.json
+++ b/test/integration/config.json
@@ -84,6 +84,6 @@
         "project_id": 1,
         "project_key": "test1",
         "environment": "integration",
-        "host": "http://errbit:48088"
+        "host": "http://errbit:80"
     }
 }

--- a/test/integration/errbit/init_errbit.rake
+++ b/test/integration/errbit/init_errbit.rake
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
 require 'json'
-require 'securerandom'
 
 namespace :errbit do
   desc 'Initializes users, applications and site configs for fleet-telemetry errbit'
   task init_errbit: :environment do
-    if User.count.positive?
+    if App.where(api_key: 'test1').exists?
       p 'already initialized'
       next
     end
@@ -16,15 +15,20 @@ namespace :errbit do
       apps_config = JSON.parse(File.read('/initialize/apps.json'))
       site_configs = JSON.parse(File.read('/initialize/site_configs.json'))
 
-      User.destroy_all # Deleting default users created by errbit docker image
+      User.destroy_all # Deleting default users created by errbit bootstrap
       User.create!(user_config['users']) # Adding custom users provided in the config
-      SiteConfig.create!(site_configs)
+
+      site_config = SiteConfig.document
+      site_config.notice_fingerprinter.assign_attributes(site_configs['notice_fingerprinter'])
+      site_config.save!
+
       App.create!(apps_config['apps'])
-      
+
       p 'Successfully initialized Errbit with custom configuration'
     rescue => e
       p "Error initializing Errbit: #{e.message}"
       p e.backtrace
+      raise
     end
   end
 end

--- a/test/integration/errbit/init_errbit.sh
+++ b/test/integration/errbit/init_errbit.sh
@@ -2,13 +2,13 @@
 
 # Wait for Errbit to be up and running
 echo "Waiting for Errbit to start..."
-until $(curl --output /dev/null --silent --head --fail http://errbit:8080); do
+until $(curl --output /dev/null --silent --head --fail http://errbit:80/up); do
     printf '.'
     sleep 5
 done
 echo "Errbit is up!"
 
 # Run the initialization task
-docker-compose exec -T errbit bundle exec rake errbit:init_errbit
+docker compose exec -T errbit bundle exec rails errbit:init_errbit
 
 echo "Errbit initialization completed!"

--- a/test/integration/errbit/users.json
+++ b/test/integration/errbit/users.json
@@ -5,7 +5,7 @@
       "per_page": 30,
       "time_zone": "Pacific Time (US & Canada)",
       "email": "noreply@example.org",
-      "password": "test123",
+      "password": "test1234",
       "github_login": "noreply",
       "admin": true
     }

--- a/test/integration/grafana/provisioning/dashboards/dashboard.json
+++ b/test/integration/grafana/provisioning/dashboards/dashboard.json
@@ -1979,6 +1979,289 @@
             ],
             "title": "MQTT Errors",
             "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${data_source}"
+            },
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green"
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 60
+            },
+            "id": 19,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${data_source}"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(rate(redis_publish_total{}[$interval])) by (record_type)",
+                    "instant": false,
+                    "legendFormat": "__auto",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Redis Records Dispatched",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${data_source}"
+            },
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green"
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "decbytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 60
+            },
+            "id": 20,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${data_source}"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(rate(redis_publish_total_bytes{}[$interval])) by (record_type)",
+                    "instant": false,
+                    "legendFormat": "__auto",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Redis Records Size",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${data_source}"
+            },
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green"
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 60
+            },
+            "id": 21,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${data_source}"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(rate(redis_err{}[$interval])) by (record_type)",
+                    "instant": false,
+                    "legendFormat": "__auto",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Redis Errors",
+            "type": "timeseries"
         }
     ],
     "refresh": "5s",

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -1,11 +1,11 @@
 package integration_test
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"testing"
 
+	. "github.com/onsi/ginkgo/v2"
 	types "github.com/onsi/ginkgo/v2/types"
+	. "github.com/onsi/gomega"
 )
 
 func TestTelemetry(t *testing.T) {

--- a/tools/main.go
+++ b/tools/main.go
@@ -57,7 +57,7 @@ func getCertFilename(cert *x509.Certificate) string {
 		log.Fatalf("invalid certificate type: %v", cert.Issuer)
 	}
 	clientType = strings.TrimSuffix(clientType, " CA")
-	clientType = strings.Replace(strings.ToLower(clientType), " ", "_", -1)
+	clientType = strings.ReplaceAll(strings.ToLower(clientType), " ", "_")
 	if clientName == "" {
 		return clientType
 	}


### PR DESCRIPTION
# Description

- Build and CI use Go 1.26; golangci-lint moves to v2 so lint works on the new toolchain
- Integration Errbit is 0.11.2 on Mongo 8.2, with startup init updated for the new image (password min length 8)
- Point Airbrake at Errbit's container port (80), not the host mapped port (48088)
- Pin Prometheus and Grafana image tags; add Redis panels to the Grafana dashboard


## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [X] My code follows the style of this project.
- [X] I have performed a self-review of my code.
- [X] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
- [ ] I have added/updated integration tests to cover my changes.
