### PR TITLE
middleware: capture status, size, and body in WrappedResponseWriter

### DIFF
--- a/server/airbrake/airbrake_test.go
+++ b/server/airbrake/airbrake_test.go
@@ -37,7 +37,7 @@ var _ = Describe("AirbrakeMiddleware", func() {
 			Expect(responseBody).To(Equal([]byte(body)))
 		},
 		Entry("404", http.StatusNotFound, "not found"),
-		Entry("400", http.StatusInternalServerError, "bad error"),
+		Entry("500", http.StatusInternalServerError, "bad error"),
 		Entry("200", http.StatusOK, "ok"),
 	)
 

--- a/server/middleware/middleware_suite_test.go
+++ b/server/middleware/middleware_suite_test.go
@@ -1,0 +1,13 @@
+package middleware
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfigs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Middleware Suite Tests")
+}

--- a/server/middleware/wrapped_response_writer.go
+++ b/server/middleware/wrapped_response_writer.go
@@ -49,6 +49,22 @@ func (w *WrappedResponseWriter) Header() http.Header {
 	return w.ResponseWriter.Header()
 }
 
+// WriteHeader captures the status code and passes through to the response writer
+func (w *WrappedResponseWriter) WriteHeader(status int) {
+	w.status = status
+	w.ResponseWriter.WriteHeader(status)
+}
+
+// Write captures the response body and size and passes through to the response writer
+func (w *WrappedResponseWriter) Write(b []byte) (int, error) {
+	n, err := w.ResponseWriter.Write(b)
+	w.size += n
+	chunk := make([]byte, n)
+	copy(chunk, b[:n])
+	w.body = append(w.body, chunk)
+	return n, err
+}
+
 // ShouldReportOnAirbrake returns true if response code is 5xx
 func (w *WrappedResponseWriter) ShouldReportOnAirbrake() bool {
 	return w.status >= 500 && w.status <= 599

--- a/server/middleware/wrapped_response_writer_test.go
+++ b/server/middleware/wrapped_response_writer_test.go
@@ -1,0 +1,45 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("WrappedResponseWriter", func() {
+	var (
+		recorder *httptest.ResponseRecorder
+		wrapped  *WrappedResponseWriter
+	)
+
+	BeforeEach(func() {
+		recorder = httptest.NewRecorder()
+		wrapped = NewWrappedResponseWriter(recorder)
+	})
+
+	It("captures status, size, and body", func() {
+		wrapped.WriteHeader(http.StatusBadGateway)
+		_, err := wrapped.Write([]byte("bad "))
+		Expect(err).NotTo(HaveOccurred())
+		_, err = wrapped.Write([]byte("gateway"))
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(wrapped.Status()).To(Equal(http.StatusBadGateway))
+		Expect(wrapped.Size()).To(Equal(len("bad gateway")))
+		Expect(wrapped.Body()).To(Equal([]byte("bad gateway")))
+		Expect(wrapped.ShouldReportOnAirbrake()).To(BeTrue())
+
+		Expect(recorder.Code).To(Equal(http.StatusBadGateway))
+		Expect(recorder.Body.Bytes()).To(Equal([]byte("bad gateway")))
+	})
+
+	It("defaults to 200 and does not report on airbrake", func() {
+		_, err := wrapped.Write([]byte("ok"))
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(wrapped.Status()).To(Equal(http.StatusOK))
+		Expect(wrapped.ShouldReportOnAirbrake()).To(BeFalse())
+	})
+})


### PR DESCRIPTION
## Problem

`WrappedResponseWriter` has `status`, `size`, and `body` fields and exposes `Status()`/`Size()`/`Body()`/`ShouldReportOnAirbrake()`, but never overrides `Write` or `WriteHeader` — handler calls promote straight to the embedded `http.ResponseWriter`, so `status` stays at the constructor's 200, `size` at 0, and `body` empty.

Consequence: `ShouldReportOnAirbrake()` (`status >= 500`) can never return true, so the `WithReporting` middleware **never reports 5xx responses to Airbrake**, and `httpAirbrakeMessage` would always see an empty body and status 200. The existing airbrake test only asserts pass-through behavior, which is why this wasn't caught.

## Fix

- Add the missing `WriteHeader` and `Write` overrides (`Write` copies each chunk since handlers may reuse their buffers).
- Add a middleware test suite covering capture and the 200 default.
- Fix a mislabeled airbrake test entry (`"400"` → `"500"` for `http.StatusInternalServerError`).

`go test ./server/middleware/ ./server/airbrake/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)