### PR TITLE
config: wire message_interval_time into the rate limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ For ease of installation and operation, run Fleet Telemetry on Kubernetes or a s
   },
   "rate_limit": {
     "enabled": bool,
-    "message_limit": int - ex.: 1000
+    "message_limit": int - ex.: 1000,
+    "message_interval_time": int - rate limit interval in seconds, ex.: 30
   },
   "records": { // list of records and their dispatchers, currently: alerts, errors, and V(vehicle data)
     "alerts": [

--- a/config/config_initializer.go
+++ b/config/config_initializer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/sirupsen/logrus/hooks/test"
 
@@ -52,6 +53,10 @@ func loadApplicationConfig(configFilePath string) (*Config, error) {
 	err = json.NewDecoder(configFile).Decode(&config)
 	if err != nil {
 		return nil, err
+	}
+
+	if config.RateLimit != nil {
+		config.RateLimit.MessageIntervalTimeSecond = time.Duration(config.RateLimit.MessageInterval) * time.Second
 	}
 
 	log, _ := test.NewNullLogger()


### PR DESCRIPTION
## Problem

The websocket rate limiter is constructed from `RateLimit.MessageIntervalTimeSecond` (`server/streaming/socket.go`):

```go
rl = rate.New(sm.config.RateLimit.MessageLimit, sm.config.RateLimit.MessageIntervalTimeSecond)
```

But that field has no JSON tag and is never populated when the config is loaded — only tests set it directly (`grep -rn MessageIntervalTimeSecond` over non-test code finds only the declaration and the read above). For every config-driven deployment the interval is 0, and go-rate's `Try()` never limits with a zero interval (`diff < r.interval` can't be true).

**Net effect: `"rate_limit": {"enabled": true, ...}` — as in `examples/server_config.json` — silently does nothing.**

## Fix

- Populate `MessageIntervalTimeSecond` from the decoded `message_interval_time` value (seconds, matching the example config) in `loadApplicationConfig`.
- Document `message_interval_time` in the README's `rate_limit` block, which previously omitted it.

`go build` and `go vet ./config/...` pass locally (the config test binary needs an arm64 libzmq to link, which this machine lacks — CI will exercise it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)