### PR TITLE
streaming: return after acking unknown message types

### DIFF
--- a/server/streaming/socket.go
+++ b/server/streaming/socket.go
@@ -264,6 +264,7 @@ func (sm *SocketManager) ParseAndProcessRecord(serializer *telemetry.BinarySeria
 			sm.logger.ErrorLog("unknown_message_type_error", err, logInfo)
 			metricsRegistry.unknownMessageTypeErrorCount.Inc(map[string]string{"msg_type": string(typedError.GuessedType)})
 			sm.respondToVehicle(record, nil) // respond to the client message was accepted so they are not resending it over and over
+			return
 		default:
 			sm.respondToVehicle(record, err)
 			return

--- a/server/streaming/socket_test.go
+++ b/server/streaming/socket_test.go
@@ -84,6 +84,15 @@ var _ = Describe("Socket test", func() {
 			Expect(envelope.MessageType()).To(Equal(tesla.MessageFlatbuffersStreamAck))
 			lastLogEntry := hook.LastEntry()
 			Expect(lastLogEntry.Message).To(ContainSubstring("unknown_message_type_error"))
+
+			// the record must not fall through to the success path:
+			// no bytes are recorded against an empty record type ...
+			Expect(sm.RecordsStats).To(BeEmpty())
+
+			// ... and the vehicle is acked exactly once
+			extra := make(chan streaming.SocketMessage, 1)
+			go func() { extra <- sm.ListenToWriteChannel() }()
+			Consistently(extra).ShouldNot(Receive())
 		})
 
 		It("returns error for unknown topic and unmatched sender", func() {


### PR DESCRIPTION
## Problem

In `ParseAndProcessRecord`, the `UnknownMessageType` case acks the message but — unlike both sibling cases (`UnauthorizedSenderIDError` and `default`) — does not `return`. Control falls through to the success path, so a message that failed to parse is:

1. dispatched to producers via `processRecord`,
2. counted in `ReportMetricBytesPerRecords` with an empty record type, and
3. acked to the vehicle a **second** time (reliable-ack doesn't apply to an empty `TxType`).

The existing socket test reads only the first message from the write channel, so the double-ack was unobserved.

## Fix

One line: `return` after the ack, matching the sibling cases.

`go build` and `go vet ./server/streaming/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)