### PR TITLE
monitoring: document bind-address config and test listen address defaulting

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ For ease of installation and operation, run Fleet Telemetry on Kubernetes or a s
   "transmit_decoded_records": bool - if true, transmit JSON to dispatchers instead of proto.
   "monitoring": {
     "prometheus_metrics_port": int,
+    "prometheus_metrics_host": string - address to bind the metrics server to. Defaults to 127.0.0.1; set to 0.0.0.0 to expose metrics on all interfaces (e.g. for Kubernetes liveness probes),
     "profiler_port": int,
+    "profiler_host": string - address to bind the profiler to. Defaults to 127.0.0.1,
     "profiling_path": string - out path,
     "statsd": { if not using prometheus
       "host": string - host:port of the statsd server,

--- a/server/monitoring/metrics_server.go
+++ b/server/monitoring/metrics_server.go
@@ -28,6 +28,17 @@ var (
 	metricsOnce     sync.Once
 )
 
+// listenAddress builds the host:port a monitoring server binds to, defaulting
+// to localhost when no host is configured. Set prometheus_metrics_host or
+// profiler_host to 0.0.0.0 to expose the server on all interfaces, e.g. for
+// Kubernetes liveness probes.
+func listenAddress(host string, port int) string {
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	return fmt.Sprintf("%s:%d", host, port)
+}
+
 // StartServerMetrics initializes the metrics server on http
 func StartServerMetrics(config *config.Config, logger *logrus.Logger, registry *streaming.SocketRegistry) {
 	registerMetricsOnce(config.MetricCollector)
@@ -36,11 +47,7 @@ func StartServerMetrics(config *config.Config, logger *logrus.Logger, registry *
 		promMux := http.NewServeMux()
 		promMux.Handle("/metrics", promhttp.Handler())
 		go func() {
-			metricsHost := config.Monitoring.PrometheusMetricsHost
-			if metricsHost == "" {
-				metricsHost = "127.0.0.1"
-			}
-			if err := http.ListenAndServe(fmt.Sprintf("%s:%d", metricsHost, config.Monitoring.PrometheusMetricsPort), promMux); err != nil {
+			if err := http.ListenAndServe(listenAddress(config.Monitoring.PrometheusMetricsHost, config.Monitoring.PrometheusMetricsPort), promMux); err != nil {
 				logger.ErrorLog("metrics_server_err", err, nil)
 			}
 		}()
@@ -57,11 +64,7 @@ func StartServerMetrics(config *config.Config, logger *logrus.Logger, registry *
 
 			StartProfilerServer(config, profilerMux, logger)
 
-			profilerHost := config.Monitoring.ProfilerHost
-			if profilerHost == "" {
-				profilerHost = "127.0.0.1"
-			}
-			if err := http.ListenAndServe(fmt.Sprintf("%s:%d", profilerHost, config.Monitoring.ProfilerPort), profilerMux); err != nil {
+			if err := http.ListenAndServe(listenAddress(config.Monitoring.ProfilerHost, config.Monitoring.ProfilerPort), profilerMux); err != nil {
 				logger.ErrorLog("profiler_listen_error", err, nil)
 			}
 		}()

--- a/server/monitoring/metrics_server_test.go
+++ b/server/monitoring/metrics_server_test.go
@@ -1,0 +1,60 @@
+package monitoring
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/teslamotors/fleet-telemetry/config"
+	logrus "github.com/teslamotors/fleet-telemetry/logger"
+	"github.com/teslamotors/fleet-telemetry/metrics"
+	"github.com/teslamotors/fleet-telemetry/metrics/adapter/noop"
+	"github.com/teslamotors/fleet-telemetry/server/streaming"
+)
+
+var _ = Describe("Metrics server", func() {
+	Describe("listenAddress", func() {
+		It("defaults to localhost when no host is configured", func() {
+			Expect(listenAddress("", 9273)).To(Equal("127.0.0.1:9273"))
+		})
+
+		It("uses the configured host", func() {
+			Expect(listenAddress("0.0.0.0", 9273)).To(Equal("0.0.0.0:9273"))
+			Expect(listenAddress("10.48.1.5", 4269)).To(Equal("10.48.1.5:4269"))
+		})
+	})
+
+	Describe("StartServerMetrics", func() {
+		It("serves prometheus metrics on the configured address", func() {
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			Expect(err).NotTo(HaveOccurred())
+			port := listener.Addr().(*net.TCPAddr).Port
+			Expect(listener.Close()).To(Succeed())
+
+			logger, _ := logrus.NoOpLogger()
+			conf := &config.Config{
+				MetricCollector: noop.NewCollector(),
+				Monitoring: &metrics.MonitoringConfig{
+					PrometheusMetricsHost: "127.0.0.1",
+					PrometheusMetricsPort: port,
+				},
+			}
+			StartServerMetrics(conf, logger, streaming.NewSocketRegistry())
+
+			Eventually(func() error {
+				resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/metrics", port))
+				if err != nil {
+					return err
+				}
+				defer func() { _ = resp.Body.Close() }()
+				if resp.StatusCode != http.StatusOK {
+					return fmt.Errorf("unexpected status: %d", resp.StatusCode)
+				}
+				return nil
+			}).Should(Succeed())
+		})
+	})
+})

--- a/server/monitoring/monitoring_suite_test.go
+++ b/server/monitoring/monitoring_suite_test.go
@@ -1,0 +1,13 @@
+package monitoring
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMonitoring(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Monitoring Suite Tests")
+}


### PR DESCRIPTION
## Problem

Since the monitoring servers were bound to localhost (v0.9.0), operators relying on external access to `:9273/metrics` — most visibly Kubernetes liveness probes, which connect via the pod IP — see connection refused and containers restart-looping (#458). Users in that issue resorted to downgrading to v0.8.0.

The `prometheus_metrics_host` and `profiler_host` config fields that solve this have existed since the same commit (and the integration test config already uses `"prometheus_metrics_host": "0.0.0.0"`), but they are not mentioned anywhere in the README, so affected operators had no discoverable fix.

## Changes

- **README**: document `prometheus_metrics_host` and `profiler_host` in the monitoring config block, noting the `127.0.0.1` default and the `0.0.0.0` option for exposing metrics (e.g. to Kubernetes probes).
- **`server/monitoring/metrics_server.go`**: deduplicate the identical host-defaulting logic from the two server goroutines into a `listenAddress` helper. No behavior change — the localhost default from the security hardening is kept.
- **Tests**: add the monitoring package's first test suite:
  - `listenAddress` defaults to `127.0.0.1` when no host is configured (fails if the default ever changes silently),
  - configured hosts are used verbatim,
  - `StartServerMetrics` actually serves `/metrics` on the configured address (ephemeral port, loopback only).

## Verification

`go build ./server/...`, `go vet ./server/monitoring/`, and `go test ./server/monitoring/` all pass. Mutating the default host makes the suite fail, so the default is pinned by tests.

Addresses the actionable part of #458; whether the Helm chart probes should target `/status` on the main port instead is left to maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)