### PR TITLE
config: replace deprecated CertPool.Subjects in tests with CertPool.Equal

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"crypto/x509"
 	"io"
 	"os"
 
@@ -92,7 +93,9 @@ var _ = Describe("Test full application config", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(tls).NotTo(BeNil())
 			Expect(tls.ClientCAs).NotTo(BeNil())
-			Expect(tls.ClientCAs.Subjects()).To(HaveLen(14)) //nolint:staticcheck
+			expected := x509.NewCertPool()
+			Expect(expected.AppendCertsFromPEM(defaultProdCA)).To(BeTrue())
+			Expect(tls.ClientCAs.Equal(expected)).To(BeTrue())
 		})
 
 		It("uses eng CA", func() {
@@ -103,7 +106,21 @@ var _ = Describe("Test full application config", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(tls).NotTo(BeNil())
 			Expect(tls.ClientCAs).NotTo(BeNil())
-			Expect(tls.ClientCAs.Subjects()).To(HaveLen(8)) //nolint:staticcheck
+			expected := x509.NewCertPool()
+			Expect(expected.AppendCertsFromPEM(defaultEngCA)).To(BeTrue())
+			Expect(tls.ClientCAs.Equal(expected)).To(BeTrue())
+		})
+
+		It("appends a custom CA to the default pool", func() {
+			config.TLS.CAFile = "files/eng_ca.crt"
+
+			tls, err := config.ExtractServiceTLSConfig(log)
+			Expect(err).NotTo(HaveOccurred())
+
+			expected := x509.NewCertPool()
+			Expect(expected.AppendCertsFromPEM(defaultProdCA)).To(BeTrue())
+			Expect(expected.AppendCertsFromPEM(defaultEngCA)).To(BeTrue())
+			Expect(tls.ClientCAs.Equal(expected)).To(BeTrue())
 		})
 	})
 


### PR DESCRIPTION
## Problem

#233 tracks removing the deprecated-method usage that was suppressed when linters were enabled in #229. The original offender (`tls.Config.BuildNameToCertificate`) is already gone from production code, but two deprecated `x509.CertPool.Subjects` calls with `//nolint:staticcheck` suppressions remained in `config/config_test.go` — the last deprecated API usages in the repo.

## Changes

- Replace both `Subjects()` count assertions (`HaveLen(14)` / `HaveLen(8)`) with `x509.CertPool.Equal` (available since Go 1.19) against a pool built from the same embedded PEM (`defaultProdCA` / `defaultEngCA`). This is stronger than the old check: it asserts the `ClientCAs` pool contains exactly the embedded certificates rather than merely counting subjects, and it no longer breaks when the embedded CA files are rotated.
- Remove the two `//nolint:staticcheck` suppressions — no `Subjects()` calls remain anywhere outside vendor.
- Add a previously missing spec for the custom-CA success path: a configured `ca_file` (the embedded eng CA used as fixture) is appended on top of the default prod pool.

## Verification

`go vet ./config/` and `go test ./config/` pass. As a regression check, swapping the eng-CA branch in `ExtractServiceTLSConfig` to load the prod CA makes the "uses eng CA" spec fail, so the new assertions genuinely pin which embedded CA is loaded.

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)