### PR TITLE
streaming: track signal usage for all processed records

### DIFF
--- a/server/streaming/helper_suite_test.go
+++ b/server/streaming/helper_suite_test.go
@@ -1,6 +1,7 @@
 package streaming_test
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -9,12 +10,26 @@ import (
 	"github.com/teslamotors/fleet-telemetry/config"
 	logrus "github.com/teslamotors/fleet-telemetry/logger"
 	"github.com/teslamotors/fleet-telemetry/metrics"
+	"github.com/teslamotors/fleet-telemetry/metrics/adapter/prometheus"
+	"github.com/teslamotors/fleet-telemetry/server/streaming"
+	"github.com/teslamotors/fleet-telemetry/telemetry"
 )
 
 func TestConfigs(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Service Suite Tests")
 }
+
+// The streaming package registers its metrics once per process, with the
+// collector of the first SocketManager created. Register them with a real
+// prometheus collector before any spec runs so tests can observe emitted
+// metrics through the default prometheus gatherer.
+var _ = BeforeSuite(func() {
+	conf := CreateTestConfig()
+	conf.MetricCollector = prometheus.NewCollector()
+	logger, _ := logrus.NoOpLogger()
+	streaming.NewSocketManager(context.Background(), &telemetry.RequestIdentity{}, nil, conf, logger)
+})
 
 func CreateTestConfig() *config.Config {
 	conf := &config.Config{}

--- a/server/streaming/socket.go
+++ b/server/streaming/socket.go
@@ -210,9 +210,10 @@ func (sm *SocketManager) ProcessTelemetry(serializer *telemetry.BinarySerializer
 			// client exceeded the rate limit
 			messagesRateLimited++
 			record, _ := telemetry.NewRecord(serializer, message, sm.UUID, sm.transmitDecodedRecords)
-			sm.trackSignalUsage(record)
 			metricsRegistry.rateLimitExceededCount.Inc(map[string]string{"device_id": sm.requestIdentity.DeviceID, "txtype": record.TxType})
 			if sm.config.RateLimit != nil && sm.config.RateLimit.Enabled {
+				// the message is dropped, so it will not reach ParseAndProcessRecord where signals are tracked
+				sm.trackSignalUsage(record)
 				continue
 			}
 		}
@@ -269,6 +270,8 @@ func (sm *SocketManager) ParseAndProcessRecord(serializer *telemetry.BinarySeria
 			return
 		}
 	}
+
+	sm.trackSignalUsage(record)
 
 	// write the record out to kafka
 	sm.ReportMetricBytesPerRecords(record.TxType, record.Length())

--- a/server/streaming/socket_test.go
+++ b/server/streaming/socket_test.go
@@ -7,15 +7,51 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	prom "github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus/hooks/test"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/teslamotors/fleet-telemetry/config"
 	logrus "github.com/teslamotors/fleet-telemetry/logger"
 	"github.com/teslamotors/fleet-telemetry/messages"
 	"github.com/teslamotors/fleet-telemetry/messages/tesla"
+	"github.com/teslamotors/fleet-telemetry/protos"
 	"github.com/teslamotors/fleet-telemetry/server/streaming"
 	"github.com/teslamotors/fleet-telemetry/telemetry"
 )
+
+// gaugeValue reads a gauge from the default prometheus gatherer, returning 0
+// when the metric or label combination has not been reported yet.
+func gaugeValue(name string, labels map[string]string) float64 {
+	families, err := prom.DefaultGatherer.Gather()
+	Expect(err).NotTo(HaveOccurred())
+
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			matched := map[string]string{}
+			for _, label := range metric.GetLabel() {
+				matched[label.GetName()] = label.GetValue()
+			}
+			if len(matched) != len(labels) {
+				continue
+			}
+			found := true
+			for key, value := range labels {
+				if matched[key] != value {
+					found = false
+					break
+				}
+			}
+			if found {
+				return metric.GetGauge().GetValue()
+			}
+		}
+	}
+	return 0
+}
 
 var _ = Describe("Socket test", func() {
 	var (
@@ -128,6 +164,59 @@ var _ = Describe("Socket test", func() {
 			Expect(hook.Entries).To(HaveLen(0))
 
 			Expect(string(streamMessage.MessageTopic)).To(Equal("canlogs"))
+		})
+
+		It("tracks signal usage for processed records", func() {
+			conf.VinsSignalTrackingEnabled = []string{"42"}
+			sm := streaming.NewSocketManager(context.Background(), requestIdentity, nil, conf, logger)
+
+			payload := &protos.Payload{
+				Data: []*protos.Datum{
+					{Key: protos.Field_VehicleName, Value: &protos.Value{Value: &protos.Value_StringValue{StringValue: "car"}}},
+					{Key: protos.Field_Odometer, Value: &protos.Value{Value: &protos.Value_DoubleValue{DoubleValue: 42000}}},
+				},
+			}
+			payloadBytes, err := proto.Marshal(payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			record := messages.StreamMessage{TXID: []byte("1234"), SenderID: []byte("vehicle_device.42"), MessageTopic: []byte("V"), Payload: payloadBytes}
+			recordMsg, err := record.ToBytes()
+			Expect(err).NotTo(HaveOccurred())
+
+			signalLabels := map[string]string{"record_type": "V"}
+			vinLabels := map[string]string{"vin": "42", "record_type": "V"}
+			signalsBefore := gaugeValue("signal_count", signalLabels)
+			vinSignalsBefore := gaugeValue("vin_signal_count", vinLabels)
+
+			sm.ParseAndProcessRecord(serializer, recordMsg)
+
+			msg := sm.ListenToWriteChannel()
+			_, err = messages.StreamAckMessageFromBytes(msg.Msg)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(gaugeValue("signal_count", signalLabels) - signalsBefore).To(Equal(2.0))
+			Expect(gaugeValue("vin_signal_count", vinLabels) - vinSignalsBefore).To(Equal(2.0))
+		})
+
+		It("does not track vin signal usage for untracked vins", func() {
+			payload := &protos.Payload{
+				Data: []*protos.Datum{
+					{Key: protos.Field_Odometer, Value: &protos.Value{Value: &protos.Value_DoubleValue{DoubleValue: 42000}}},
+				},
+			}
+			payloadBytes, err := proto.Marshal(payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			record := messages.StreamMessage{TXID: []byte("1234"), SenderID: []byte("vehicle_device.42"), MessageTopic: []byte("V"), Payload: payloadBytes}
+			recordMsg, err := record.ToBytes()
+			Expect(err).NotTo(HaveOccurred())
+
+			vinLabels := map[string]string{"vin": "42", "record_type": "V"}
+			vinSignalsBefore := gaugeValue("vin_signal_count", vinLabels)
+
+			sm.ParseAndProcessRecord(serializer, recordMsg)
+
+			Expect(gaugeValue("vin_signal_count", vinLabels)).To(Equal(vinSignalsBefore))
 		})
 
 		It("empty network interface", func() {


### PR DESCRIPTION
## Problem

#351 reports that configuring `vins_signal_tracking_enabled` produces no `vin_signal_count` (or `signal_count`) metrics on `/metrics`.

Root cause: `trackSignalUsage` has exactly one call site — inside the rate-limit-exceeded branch of `ProcessTelemetry`. Messages that are processed normally never reach it, so:

- with rate limiting **enabled**, only messages that are *dropped* for exceeding the limit are counted;
- with rate limiting **disabled**, only messages beyond the fallback limiter's 100/min are counted (and those *are* processed, while messages under the limit are not counted at all).

Either way, the gauges are silent in normal operation, which is exactly what the issue describes.

## Fix

- Call `sm.trackSignalUsage(record)` in `ParseAndProcessRecord` once the record parses successfully, so every processed record is counted.
- Move the existing rate-limit-branch call inside the `RateLimit.Enabled` guard, so it now only covers messages dropped before reaching `ParseAndProcessRecord` — nothing is counted twice on the disabled-rate-limit fallthrough path.

Records that fail to parse are not tracked (they have no signals and an empty record type).

## Tests

The streaming metrics registry is per-process, first-collector-wins, so the suite now registers it with a real prometheus collector in `BeforeSuite`; specs observe gauge values through the default prometheus gatherer (delta-based, so they are robust to other specs contributing to the same gauges).

- `tracks signal usage for processed records`: a valid `V` payload with 2 datums for a tracked VIN increments both `signal_count{record_type="V"}` and `vin_signal_count{vin,record_type}` by 2.
- `does not track vin signal usage for untracked vins`: same payload without `vins_signal_tracking_enabled` leaves `vin_signal_count` untouched.

## Verification

`go vet` and `go test ./server/streaming/` pass (3 consecutive runs, no flakes). Reverting the `ParseAndProcessRecord` call makes the new spec fail, so the regression is pinned.

Fixes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)