### PR TITLE
kafka: pin vin message keying with tests and document partitioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Vehicles must be running firmware version 2023.20.6 or later.  Some older model 
 Dispatchers handle vehicle data processing upon its arrival at Fleet Telemetry servers. They can be of any type, from distributed message queues to  STDOUT logger.  Here is a list of the currently supported [dispatchers](./telemetry/producer.go#L13-L26)::
 * Kafka (preferred): Configure with the config.json file.  See implementation here: [config/config.go](./config/config.go)
   * Topics will need to be created for \*prefix\*`_V`,\*prefix\*`_connectivity` and \*prefix\*`_alerts`. The default prefix is `tesla`
+  * Messages are produced with the vehicle VIN as the message key, so with librdkafka's default partitioner all records for a vehicle land on the same partition and stay ordered relative to each other. To change the partitioning strategy, set the librdkafka `partitioner` property (e.g. `"partitioner": "murmur2_random"`) in the `kafka` config block.
 * Kinesis: Configure with standard [AWS env variables and config files](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html). The default AWS credentials and config files are: `~/.aws/credentials` and `~/.aws/config`.
   * By default, stream names will be \*configured namespace\*_\*topic_name\*  ex.: `tesla_V`, `tesla_alerts`, etc
   * Configure stream names directly by setting the streams config `"kinesis": { "streams": { *topic_name*: stream_name } }`

--- a/datastore/kafka/kafka.go
+++ b/datastore/kafka/kafka.go
@@ -73,15 +73,7 @@ func NewProducer(config *kafka.ConfigMap, namespace string, prometheusEnabled bo
 // Produce asynchronously sends the record payload to kafka
 func (p *Producer) Produce(entry *telemetry.Record) {
 	topic := telemetry.BuildTopicName(p.namespace, entry.TxType)
-
-	msg := &kafka.Message{
-		TopicPartition: kafka.TopicPartition{Topic: &topic, Partition: kafka.PartitionAny},
-		Value:          entry.Payload(),
-		Key:            []byte(entry.Vin),
-		Headers:        headersFromRecord(entry),
-		Timestamp:      time.Now(),
-		Opaque:         entry,
-	}
+	msg := buildMessage(entry, topic)
 
 	// Note: confluent kafka supports the concept of one channel per connection, so we could add those here and get rid of reliableAckWorkers
 	// ex.: https://github.com/confluentinc/confluent-kafka-go/blob/master/examples/producer_custom_channel_example/producer_custom_channel_example.go#L79
@@ -98,6 +90,21 @@ func (p *Producer) Produce(entry *telemetry.Record) {
 func (p *Producer) ReportError(message string, err error, logInfo logrus.LogInfo) {
 	p.airbrakeHandler.ReportLogMessage(logrus.ERROR, message, err, logInfo)
 	p.logger.ErrorLog(message, err, logInfo)
+}
+
+// buildMessage assembles the kafka message for a record. The record's vin is
+// the message key, so all of a vehicle's records hash to the same partition
+// and stay ordered relative to each other with librdkafka's default
+// partitioner. Set `partitioner` in the kafka config to override.
+func buildMessage(entry *telemetry.Record, topic string) *kafka.Message {
+	return &kafka.Message{
+		TopicPartition: kafka.TopicPartition{Topic: &topic, Partition: kafka.PartitionAny},
+		Value:          entry.Payload(),
+		Key:            []byte(entry.Vin),
+		Headers:        headersFromRecord(entry),
+		Timestamp:      time.Now(),
+		Opaque:         entry,
+	}
 }
 
 func headersFromRecord(record *telemetry.Record) (headers []kafka.Header) {

--- a/datastore/kafka/kafka_suite_test.go
+++ b/datastore/kafka/kafka_suite_test.go
@@ -1,0 +1,13 @@
+package kafka
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestKafka(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Kafka Producer Suite Tests")
+}

--- a/datastore/kafka/kafka_test.go
+++ b/datastore/kafka/kafka_test.go
@@ -1,0 +1,46 @@
+package kafka
+
+import (
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/teslamotors/fleet-telemetry/telemetry"
+)
+
+var _ = Describe("buildMessage", func() {
+	var record *telemetry.Record
+
+	BeforeEach(func() {
+		record = &telemetry.Record{
+			Vin:          "TESTVIN000000042",
+			TxType:       "V",
+			Txid:         "1234",
+			PayloadBytes: []byte("payload"),
+		}
+	})
+
+	It("keys the message by vin so a vehicle's records stay on one partition", func() {
+		msg := buildMessage(record, "tesla_V")
+
+		Expect(msg.Key).To(Equal([]byte("TESTVIN000000042")))
+		Expect(*msg.TopicPartition.Topic).To(Equal("tesla_V"))
+		Expect(msg.TopicPartition.Partition).To(Equal(kafka.PartitionAny))
+	})
+
+	It("carries the payload, metadata headers, and the record as opaque", func() {
+		msg := buildMessage(record, "tesla_V")
+
+		Expect(msg.Value).To(Equal([]byte("payload")))
+		Expect(msg.Opaque).To(BeIdenticalTo(record))
+
+		headers := map[string]string{}
+		for _, header := range msg.Headers {
+			headers[header.Key] = string(header.Value)
+		}
+		Expect(headers).To(HaveKeyWithValue("vin", "TESTVIN000000042"))
+		Expect(headers).To(HaveKeyWithValue("txid", "1234"))
+		Expect(headers).To(HaveKeyWithValue("txtype", "V"))
+	})
+})

--- a/telemetry/record.go
+++ b/telemetry/record.go
@@ -31,7 +31,8 @@ var (
 )
 
 // Record is a structs that represents the telemetry records vehicles send to the backend
-// vin is used as kafka produce partitioning key by default, can be configured to random
+// vin is used as the kafka message key, keeping each vehicle's records on one
+// partition; override with the `partitioner` setting in the kafka config
 type Record struct {
 	ProduceTime            time.Time
 	ReceivedTimestamp      int64


### PR DESCRIPTION
## Problem

#354 asks for a configurable partitioning strategy so all messages for a vehicle land on the same partition, and a maintainer replied "Reading the code, I'm surprised this isn't happening already. Happy to accept a PR."

It turns out the behavior already exists — and has since the producer was introduced: `Produce` keys every message with the vehicle VIN, and librdkafka's default partitioner (`consistent_random`) hashes keyed messages consistently, so a vehicle's records already stay on one partition, in order. A different strategy is already selectable through the librdkafka passthrough config (e.g. `"partitioner": "murmur2_random"`), as one commenter discovered independently.

What was missing is everything around it: no test protected the VIN-keying contract (the kafka datastore package had no tests at all), the README never mentioned partitioning or the `partitioner` override, and the `Record` struct comment claimed VIN keying "can be configured to random" — a configuration that does not exist.

## Changes

- **`datastore/kafka/kafka.go`**: extract message construction into `buildMessage` so the produce contract is testable; no behavior change.
- **Tests** (first for this package): pin that the message key is the VIN with `PartitionAny`, and that payload, metadata headers, and the record opaque ride along.
- **README**: document per-VIN partition affinity under the Kafka dispatcher and how to override the strategy via the `partitioner` property in the `kafka` config block.
- **`telemetry/record.go`**: correct the stale comment referencing a nonexistent "random" configuration.

## Verification

`go build`, `go vet`, and `go test ./datastore/kafka/` pass. Mutating the key to `nil` makes the keying spec fail, so the contract is genuinely pinned.

Addresses #354 — with the behavior confirmed, tested, and documented, the issue can likely be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)