### PR TITLE
zmq: serialize socket access, producer is shared across connections

### DIFF
--- a/datastore/zmq/zmq.go
+++ b/datastore/zmq/zmq.go
@@ -63,6 +63,7 @@ type Producer struct {
 	namespace          string
 	ctx                context.Context
 	sock               *zmq4.Socket
+	sockMutex          sync.Mutex
 	logger             *logrus.Logger
 	airbrakeHandler    *airbrake.Handler
 	ackChan            chan (*telemetry.Record)
@@ -74,7 +75,7 @@ func (p *Producer) Produce(rec *telemetry.Record) {
 	if p.ctx.Err() != nil {
 		return
 	}
-	nBytes, err := p.sock.SendMessage(telemetry.BuildTopicName(p.namespace, rec.TxType), rec.Payload())
+	nBytes, err := p.sendMessage(rec)
 	if err != nil {
 		metricsRegistry.errorCount.Inc(map[string]string{"record_type": rec.TxType})
 		p.ReportError("zmq_dispatch_error", err, nil)
@@ -85,6 +86,19 @@ func (p *Producer) Produce(rec *telemetry.Record) {
 	metricsRegistry.publishCount.Inc(map[string]string{"record_type": rec.TxType})
 }
 
+// sendMessage publishes to the socket under the socket mutex: zmq sockets are
+// not thread safe, and every vehicle connection produces from its own
+// goroutine. Concurrent unsynchronized sends corrupt libzmq internal state and
+// crash the process.
+func (p *Producer) sendMessage(rec *telemetry.Record) (int, error) {
+	p.sockMutex.Lock()
+	defer p.sockMutex.Unlock()
+	if p.sock == nil {
+		return 0, zmq4.ErrorSocketClosed
+	}
+	return p.sock.SendMessage(telemetry.BuildTopicName(p.namespace, rec.TxType), rec.Payload())
+}
+
 // ReportError to airbrake and logger
 func (p *Producer) ReportError(message string, err error, logInfo logrus.LogInfo) {
 	p.airbrakeHandler.ReportLogMessage(logrus.ERROR, message, err, logInfo)
@@ -93,6 +107,8 @@ func (p *Producer) ReportError(message string, err error, logInfo logrus.LogInfo
 
 // Close the underlying socket.
 func (p *Producer) Close() error {
+	p.sockMutex.Lock()
+	defer p.sockMutex.Unlock()
 	if p.sock != nil {
 		if err := p.sock.Close(); err != nil {
 			return err

--- a/datastore/zmq/zmq_suite_test.go
+++ b/datastore/zmq/zmq_suite_test.go
@@ -1,0 +1,13 @@
+package zmq
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestZMQ(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ZMQ Producer Suite Tests")
+}

--- a/datastore/zmq/zmq_test.go
+++ b/datastore/zmq/zmq_test.go
@@ -1,0 +1,70 @@
+package zmq
+
+import (
+	"context"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	logrus "github.com/teslamotors/fleet-telemetry/logger"
+	"github.com/teslamotors/fleet-telemetry/metrics/adapter/noop"
+	"github.com/teslamotors/fleet-telemetry/server/airbrake"
+	"github.com/teslamotors/fleet-telemetry/telemetry"
+)
+
+var _ = Describe("ZMQ producer", func() {
+	var producer *Producer
+
+	BeforeEach(func() {
+		logger, _ := logrus.NoOpLogger()
+		config := &Config{Addr: "tcp://127.0.0.1:*"}
+		zmqProducer, err := NewProducer(context.Background(), config, noop.NewCollector(), "tesla", airbrake.NewAirbrakeHandler(nil), nil, nil, logger)
+		Expect(err).NotTo(HaveOccurred())
+		producer = zmqProducer.(*Producer)
+	})
+
+	AfterEach(func() {
+		Expect(producer.Close()).To(Succeed())
+	})
+
+	It("produces safely from concurrent connections", func() {
+		record := &telemetry.Record{TxType: "V", PayloadBytes: []byte("payload"), Vin: "TESTVIN000000042"}
+
+		var wg sync.WaitGroup
+		for worker := 0; worker < 8; worker++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer GinkgoRecover()
+				for i := 0; i < 500; i++ {
+					producer.Produce(record)
+				}
+			}()
+		}
+		wg.Wait()
+	})
+
+	It("does not panic when producing after close", func() {
+		record := &telemetry.Record{TxType: "V", PayloadBytes: []byte("payload")}
+
+		Expect(producer.Close()).To(Succeed())
+		Expect(func() { producer.Produce(record) }).NotTo(Panic())
+	})
+
+	It("survives produce racing with close", func() {
+		record := &telemetry.Record{TxType: "V", PayloadBytes: []byte("payload")}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer GinkgoRecover()
+			for i := 0; i < 200; i++ {
+				producer.Produce(record)
+			}
+		}()
+		Expect(producer.Close()).To(Succeed())
+		wg.Wait()
+	})
+})


### PR DESCRIPTION
## Problem

#301 reports fleet-telemetry crashing every ~30 minutes with:

```
Bad address (src/tcp.cpp:253)
double free or corruption (top)
free(): double free detected in tcache 2
```

with the telling detail that "this problem started when I added more vehicles."

Root cause: zmq sockets are [not thread safe](http://api.zeromq.org/4-3:zmq-socket) (pebbe/zmq4 documents the same), but the ZMQ producer is shared by every vehicle connection, and each connection dispatches records from its own `ProcessTelemetry` goroutine. `Producer.Produce` called `p.sock.SendMessage` with no synchronization, so two vehicles producing at once corrupt libzmq internal state in exactly the way those abort messages describe — and the crash frequency scales with fleet size. `Close` racing `Produce` additionally nil-derefs.

(The other dispatchers don't have this problem: librdkafka, the AWS/GCP SDK clients, and go-redis are all internally thread safe. ZMQ is the odd one out.)

## Fix

Guard the socket with a mutex in `Produce` (via a small `sendMessage` helper) and `Close`. Producing after close now returns `zmq4.ErrorSocketClosed` through the existing error path instead of dereferencing a nil socket. PUB sends are non-blocking (libzmq queues or drops per HWM), so the critical section is short and the mutex adds no meaningful contention.

## Tests

First tests for the zmq package (CI already installs libzmq for the integration suite):
- concurrent produce from 8 goroutines,
- produce racing close,
- produce after close does not panic.

## Verification

`go vet`, `go test`, and `go test -race` pass. Removing the lock and nil-guard makes the suite fail on both fronts: the race detector flags the `Close`/`Produce` race and the after-close spec panics on the nil socket.

Fixes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)